### PR TITLE
Remove volume mappings for PostgreSQL and MySQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       POSTGRES_DB: drizzle_cube_test
     ports:
       - "5433:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
 
   mysql:
     image: mysql:9.4
@@ -21,10 +19,5 @@ services:
       MYSQL_PASSWORD: test
     ports:
       - "3307:3306"  # Use 3307 to avoid conflicts with local MySQL
-    volumes:
-      - mysql_data:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
-
-volumes:
-  postgres_data:
-  mysql_data:
+    


### PR DESCRIPTION
This is used mostly for testing, and we don't actually need persistent volumes. Also, having persistent volumes makes (major) version updates more difficult.