### PR TITLE
chore: replace any types with Drizzle ORM types in BaseQueryDefinition

### DIFF
--- a/src/server/types/cube.ts
+++ b/src/server/types/cube.ts
@@ -3,7 +3,7 @@
  * Core semantic layer building blocks
  */
 
-import type { SQL, AnyColumn } from 'drizzle-orm'
+import type { SQL, AnyColumn, Table, Subquery, View } from 'drizzle-orm'
 import type { 
   SecurityContext, 
   DrizzleDatabase, 
@@ -14,15 +14,21 @@ import type {
 import type { SemanticQuery } from './query'
 
 /**
+ * Any queryable relation that can be used in FROM/JOIN clauses
+ * Supports tables, views, subqueries, and raw SQL expressions
+ */
+export type QueryableRelation = Table | View | Subquery | SQL
+
+/**
  * Base query definition that can be extended dynamically
  * Returns just the FROM/JOIN/WHERE setup, not a complete SELECT
  */
 export interface BaseQueryDefinition {
   /** Main table to query from */
-  from: any
+  from: QueryableRelation
   /** Optional joins to other tables */
   joins?: Array<{
-    table: any
+    table: QueryableRelation
     on: SQL
     type?: 'left' | 'right' | 'inner' | 'full'
   }>


### PR DESCRIPTION
  - Replace `from: any` with `from: QueryableRelation`
  - Replace `joins[].table: any` with `table: QueryableRelation`
  - Add QueryableRelation type alias: Table | View | Subquery | SQL
  - Add proper imports for Table, Subquery, View from drizzle-orm
  - Maintains full backward compatibility while providing better type safety
  - Supports tables, views, subqueries, and raw SQL expressions
  - All tests pass without modification

  🤖 Generated with [Claude Code](https://claude.ai/code)

  Co-Authored-By: Claude <noreply@anthropic.com>