### PR TITLE
refactor(client): derive chart type picker labels from config registry

### DIFF
--- a/src/client/CLAUDE.md
+++ b/src/client/CLAUDE.md
@@ -470,6 +470,32 @@ interface ChartDisplayConfig {
 - **BubbleChart** - Bubble charts with size/color dimensions
 - **DataTable** - Sortable data tables
 
+### Adding a New Chart Type
+
+To add a new chart type, create the config and component files and register them. The chart type picker (`ChartTypeSelector`) derives its list automatically from `chartConfigRegistry` — no manual label map updates needed.
+
+1. **Add to `ChartType` union** in `src/client/types.ts`
+2. **Create the chart component** in `src/client/components/charts/MyChart.tsx`
+3. **Create the chart config** in `src/client/components/charts/MyChart.config.tsx`:
+   ```typescript
+   import type { ChartTypeConfig } from '../../charts/chartConfigs'
+   import { getChartTypeIcon } from '../../icons'
+
+   export const myChartConfig: ChartTypeConfig = {
+     label: 'My Chart',              // Required: display name in chart type picker
+     icon: getChartTypeIcon('bar'),   // Icon for picker and UI
+     description: 'Brief description',
+     useCase: 'When to use this chart',
+     dropZones: [ /* ... */ ],
+     displayOptionsConfig: [ /* ... */ ],
+   }
+   ```
+4. **Register in `chartConfigRegistry.ts`** — import and add the config entry
+5. **Register in `lazyChartConfigRegistry.ts`** — add dynamic import and export name mappings
+6. **Add to `ChartLoader.tsx`** — add the lazy component import
+
+The `label` field in the config is the single source of truth for the chart's display name. The picker, tooltips, and other UI automatically use it.
+
 ---
 
 ## Query Builder / AnalysisBuilder

--- a/src/client/charts/chartConfigRegistry.ts
+++ b/src/client/charts/chartConfigRegistry.ts
@@ -17,6 +17,8 @@ import { funnelChartConfig } from '../components/charts/FunnelChart.config'
 import { sankeyChartConfig } from '../components/charts/SankeyChart.config'
 import { sunburstChartConfig } from '../components/charts/SunburstChart.config'
 import { heatmapChartConfig } from '../components/charts/HeatMapChart.config'
+import { retentionHeatmapConfig } from '../components/charts/RetentionHeatmap.config'
+import { retentionCombinedConfig } from '../components/charts/RetentionCombinedChart.config'
 import type { ChartConfigRegistry } from './chartConfigs'
 
 /**
@@ -42,4 +44,6 @@ export const chartConfigRegistry: ChartConfigRegistry = {
   sankey: sankeyChartConfig,
   sunburst: sunburstChartConfig,
   heatmap: heatmapChartConfig,
+  retentionHeatmap: retentionHeatmapConfig,
+  retentionCombined: retentionCombinedConfig,
 }

--- a/src/client/charts/chartConfigs.ts
+++ b/src/client/charts/chartConfigs.ts
@@ -91,6 +91,9 @@ export interface ClickableElementsConfig {
  * Complete configuration for a chart type
  */
 export interface ChartTypeConfig {
+  /** Display label for the chart type in the picker (e.g., 'Bar Chart', 'KPI Number') */
+  label?: string
+
   /** Configuration for each drop zone */
   dropZones: AxisDropZoneConfig[]
 

--- a/src/client/components/ChartTypeSelector.tsx
+++ b/src/client/components/ChartTypeSelector.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { ChartType } from '../types'
 import type { ChartAvailabilityMap } from '../shared/chartDefaults'
-import type { ChartConfigRegistry } from '../charts/chartConfigs'
+import { chartConfigRegistry } from '../charts/chartConfigRegistry'
 
 interface ChartTypeSelectorProps {
   selectedType: ChartType
@@ -15,29 +15,9 @@ interface ChartTypeSelectorProps {
   excludeTypes?: ChartType[]
 }
 
-// Chart type display names (defined outside component to avoid recreation)
-const chartTypeLabels: Record<ChartType, string> = {
-  activityGrid: 'Activity Grid',
-  area: 'Area Chart',
-  bar: 'Bar Chart',
-  bubble: 'Bubble Chart',
-  funnel: 'Funnel Chart',
-  heatmap: 'Heatmap',
-  kpiDelta: 'KPI Delta',
-  kpiNumber: 'KPI Number',
-  kpiText: 'KPI Text',
-  line: 'Line Chart',
-  markdown: 'Markdown',
-  pie: 'Pie Chart',
-  radar: 'Radar Chart',
-  radialBar: 'Radial Bar Chart',
-  retentionCombined: 'Retention Chart',
-  retentionHeatmap: 'Retention Matrix',
-  sankey: 'Sankey Chart',
-  scatter: 'Scatter Plot',
-  sunburst: 'Sunburst Chart',
-  table: 'Data Table',
-  treemap: 'TreeMap'
+/** Get label for a chart type from the registry, falling back to the chart type key */
+function getLabel(type: ChartType): string {
+  return chartConfigRegistry[type]?.label || type
 }
 
 export default function ChartTypeSelector({
@@ -49,40 +29,17 @@ export default function ChartTypeSelector({
   excludeTypes = []
 }: ChartTypeSelectorProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [configRegistry, setConfigRegistry] = useState<ChartConfigRegistry | null>(null)
 
-  useEffect(() => {
-    let isActive = true
+  // Derive chart types from the registry, filter excluded ones, and sort alphabetically by label
+  const chartTypes = useMemo(() =>
+    (Object.keys(chartConfigRegistry) as ChartType[])
+      .filter((type) => !excludeTypes.includes(type))
+      .sort((a, b) => getLabel(a).localeCompare(getLabel(b)))
+  , [excludeTypes])
 
-    import('../charts/chartConfigRegistry')
-      .then((module) => {
-        if (isActive) {
-          setConfigRegistry(module.chartConfigRegistry)
-        }
-      })
-      .catch(() => {
-        if (isActive) {
-          setConfigRegistry(null)
-        }
-      })
-
-    return () => {
-      isActive = false
-    }
-  }, [])
-
-  // Get chart types, filter excluded ones, and sort alphabetically by label
-  const chartTypes = (Object.keys(chartTypeLabels) as ChartType[])
-    .filter((type) => !excludeTypes.includes(type))
-    .sort((a, b) => {
-      const labelA = chartTypeLabels[a] || a
-      const labelB = chartTypeLabels[b] || b
-      return labelA.localeCompare(labelB)
-    })
-
-  const selectedConfig = configRegistry?.[selectedType]
+  const selectedConfig = chartConfigRegistry[selectedType]
   const SelectedIcon = selectedConfig?.icon
-  const selectedLabel = chartTypeLabels[selectedType]
+  const selectedLabel = getLabel(selectedType)
 
   return (
     <div className={`${className} dc:relative`}>
@@ -114,9 +71,9 @@ export default function ChartTypeSelector({
           <div className="dc:p-2">
             <div className={`dc:grid dc:gap-1.5 ${compact ? 'dc:grid-cols-2' : 'dc:grid-cols-2 dc:sm:grid-cols-3 dc:lg:grid-cols-4'}`}>
               {chartTypes.map((type) => {
-                const config = configRegistry?.[type]
+                const config = chartConfigRegistry[type]
                 const IconComponent = config?.icon
-                const label = chartTypeLabels[type]
+                const label = getLabel(type)
                 const isSelected = selectedType === type
                 const description = config?.description
                 const useCase = config?.useCase

--- a/src/client/components/charts/ActivityGridChart.config.tsx
+++ b/src/client/components/charts/ActivityGridChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the activity grid chart type
  */
 export const activityGridChartConfig: ChartTypeConfig = {
+  label: 'Activity Grid',
   icon: getChartTypeIcon('activityGrid'),
   description: 'GitHub-style activity grid showing temporal patterns across different time scales',
   useCase: 'Best for visualizing activity patterns over time. Supports hour (3hr blocks × days), day (days × weeks), week (weeks × months), month (months × quarters), and quarter (quarters × years) granularities',

--- a/src/client/components/charts/AreaChart.config.tsx
+++ b/src/client/components/charts/AreaChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the area chart type
  */
 export const areaChartConfig: ChartTypeConfig = {
+  label: 'Area Chart',
   icon: getChartTypeIcon('area'),
   description: 'Emphasize magnitude of change over time',
   useCase: 'Best for showing cumulative totals, volume changes, or stacked comparisons over time',

--- a/src/client/components/charts/BarChart.config.tsx
+++ b/src/client/components/charts/BarChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the bar chart type
  */
 export const barChartConfig: ChartTypeConfig = {
+  label: 'Bar Chart',
   icon: getChartTypeIcon('bar'),
   description: 'Compare values across categories',
   useCase: 'Best for comparing discrete categories, showing rankings, or displaying changes over time',

--- a/src/client/components/charts/BubbleChart.config.tsx
+++ b/src/client/components/charts/BubbleChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the bubble chart type
  */
 export const bubbleChartConfig: ChartTypeConfig = {
+  label: 'Bubble Chart',
   icon: getChartTypeIcon('bubble'),
   description: 'Compare three dimensions of data',
   useCase: 'Best for showing relationships between three variables (X, Y, and size), market analysis',

--- a/src/client/components/charts/DataTable.config.tsx
+++ b/src/client/components/charts/DataTable.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the data table type
  */
 export const dataTableConfig: ChartTypeConfig = {
+  label: 'Data Table',
   icon: getChartTypeIcon('table'),
   description: 'Display detailed tabular data',
   useCase: 'Best for precise values, detailed analysis, sortable/filterable data exploration',

--- a/src/client/components/charts/FunnelChart.config.tsx
+++ b/src/client/components/charts/FunnelChart.config.tsx
@@ -9,6 +9,7 @@ import { getChartTypeIcon } from '../../icons'
  * pre-calculated step names, values, and conversion rates.
  */
 export const funnelChartConfig: ChartTypeConfig = {
+  label: 'Funnel Chart',
   icon: getChartTypeIcon('funnel'),
   description: 'Show conversion through sequential steps',
   useCase: 'Best for visualizing user journey funnels, sales pipelines, or multi-step processes',

--- a/src/client/components/charts/HeatMapChart.config.tsx
+++ b/src/client/components/charts/HeatMapChart.config.tsx
@@ -8,6 +8,7 @@ import { getChartTypeIcon } from '../../icons'
  * Best for showing patterns in matrix data like correlations, schedules, or category comparisons.
  */
 export const heatmapChartConfig: ChartTypeConfig = {
+  label: 'Heatmap',
   icon: getChartTypeIcon('heatmap'),
   description: 'Visualize intensity across two dimensions',
   useCase: 'Best for showing patterns in matrix data like correlations, schedules, or category comparisons',

--- a/src/client/components/charts/KpiDelta.config.tsx
+++ b/src/client/components/charts/KpiDelta.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the KPI Delta chart type
  */
 export const kpiDeltaConfig: ChartTypeConfig = {
+  label: 'KPI Delta',
   icon: getChartTypeIcon('kpiDelta'),
   description: 'Display change between latest and previous values with trend indicators',
   useCase: 'Perfect for showing performance changes over time, such as revenue growth, user acquisition changes, or other metrics where the trend and delta are more important than the absolute value',

--- a/src/client/components/charts/KpiNumber.config.tsx
+++ b/src/client/components/charts/KpiNumber.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the KPI Number chart type
  */
 export const kpiNumberConfig: ChartTypeConfig = {
+  label: 'KPI Number',
   icon: getChartTypeIcon('kpiNumber'),
   description: 'Display key performance indicators as large numbers',
   useCase: 'Perfect for showing important metrics like revenue, user count, or other key business metrics in a prominent, easy-to-read format',

--- a/src/client/components/charts/KpiText.config.tsx
+++ b/src/client/components/charts/KpiText.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the KPI Text chart type
  */
 export const kpiTextConfig: ChartTypeConfig = {
+  label: 'KPI Text',
   icon: getChartTypeIcon('kpiText'),
   description: 'Display key performance indicators as customizable text',
   useCase: 'Perfect for showing metrics with custom formatting, combining multiple values, or displaying contextual KPI information using templates',

--- a/src/client/components/charts/LineChart.config.tsx
+++ b/src/client/components/charts/LineChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the line chart type
  */
 export const lineChartConfig: ChartTypeConfig = {
+  label: 'Line Chart',
   icon: getChartTypeIcon('line'),
   description: 'Show trends and changes over time',
   useCase: 'Best for continuous data, trends, time series, and showing relationships between multiple series',

--- a/src/client/components/charts/MarkdownChart.config.tsx
+++ b/src/client/components/charts/MarkdownChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the Markdown chart type
  */
 export const markdownConfig: ChartTypeConfig = {
+  label: 'Markdown',
   icon: getChartTypeIcon('markdown'),
   description: 'Display custom markdown content with formatting',
   useCase: 'Perfect for adding documentation, notes, section headers, instructions, or formatted text to dashboards',

--- a/src/client/components/charts/PieChart.config.tsx
+++ b/src/client/components/charts/PieChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the pie chart type
  */
 export const pieChartConfig: ChartTypeConfig = {
+  label: 'Pie Chart',
   icon: getChartTypeIcon('pie'),
   description: 'Show proportions of a whole',
   useCase: 'Best for showing percentage distribution or composition of a total (limit to 5-7 slices)',

--- a/src/client/components/charts/RadarChart.config.tsx
+++ b/src/client/components/charts/RadarChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the radar chart type
  */
 export const radarChartConfig: ChartTypeConfig = {
+  label: 'Radar Chart',
   icon: getChartTypeIcon('radar'),
   description: 'Compare multiple metrics across categories',
   useCase: 'Best for multivariate comparisons, performance metrics, strengths/weaknesses analysis',

--- a/src/client/components/charts/RadialBarChart.config.tsx
+++ b/src/client/components/charts/RadialBarChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the radial bar chart type
  */
 export const radialBarChartConfig: ChartTypeConfig = {
+  label: 'Radial Bar Chart',
   icon: getChartTypeIcon('radialBar'),
   description: 'Circular progress and KPI visualization',
   useCase: 'Best for showing progress toward goals, KPIs, or comparing percentages in a compact form',

--- a/src/client/components/charts/RetentionCombinedChart.config.ts
+++ b/src/client/components/charts/RetentionCombinedChart.config.ts
@@ -8,6 +8,7 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
 
 export const retentionCombinedConfig: ChartTypeConfig = {
+  label: 'Retention Chart',
   // RetentionCombinedChart auto-configures from the retention data structure
   // No drop zones needed as the chart maps directly to retention result data
   dropZones: [],

--- a/src/client/components/charts/RetentionHeatmap.config.ts
+++ b/src/client/components/charts/RetentionHeatmap.config.ts
@@ -8,6 +8,7 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
 
 export const retentionHeatmapConfig: ChartTypeConfig = {
+  label: 'Retention Matrix',
   // RetentionHeatmap auto-configures from the retention data structure
   // No drop zones needed as the chart maps directly to cohort × period matrix
   dropZones: [],

--- a/src/client/components/charts/SankeyChart.config.tsx
+++ b/src/client/components/charts/SankeyChart.config.tsx
@@ -9,6 +9,7 @@ import { getChartTypeIcon } from '../../icons'
  * nodes and links representing user journeys.
  */
 export const sankeyChartConfig: ChartTypeConfig = {
+  label: 'Sankey Chart',
   icon: getChartTypeIcon('sankey'),
   description: 'Show flow between states or steps',
   useCase: 'Best for visualizing user journey flows, path analysis, or state transitions',

--- a/src/client/components/charts/ScatterChart.config.tsx
+++ b/src/client/components/charts/ScatterChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the scatter chart type
  */
 export const scatterChartConfig: ChartTypeConfig = {
+  label: 'Scatter Plot',
   icon: getChartTypeIcon('scatter'),
   description: 'Reveal correlations between variables',
   useCase: 'Best for identifying patterns, correlations, outliers, and relationships between two measures',

--- a/src/client/components/charts/SunburstChart.config.tsx
+++ b/src/client/components/charts/SunburstChart.config.tsx
@@ -9,6 +9,7 @@ import { getChartTypeIcon } from '../../icons'
  * radiating outward from the central starting step.
  */
 export const sunburstChartConfig: ChartTypeConfig = {
+  label: 'Sunburst Chart',
   icon: getChartTypeIcon('sunburst'),
   description: 'Show hierarchical flow as radial rings',
   useCase: 'Best for visualizing forward paths from a starting event in a compact radial layout',

--- a/src/client/components/charts/TreeMapChart.config.tsx
+++ b/src/client/components/charts/TreeMapChart.config.tsx
@@ -5,6 +5,7 @@ import { getChartTypeIcon } from '../../icons'
  * Configuration for the treemap chart type
  */
 export const treemapChartConfig: ChartTypeConfig = {
+  label: 'TreeMap',
   icon: getChartTypeIcon('treemap'),
   description: 'Visualize hierarchical data with nested rectangles',
   useCase: 'Best for showing part-to-whole relationships in hierarchical data, disk usage, budget allocation',


### PR DESCRIPTION
Move chart display labels into each chart's config file (via new `label` field on ChartTypeConfig) so ChartTypeSelector derives its list directly from chartConfigRegistry. This eliminates the manually-maintained chartTypeLabels map — adding a new chart type no longer requires touching ChartTypeSelector.

Also adds retention chart configs to the eager registry and documents the new-chart-type workflow in src/client/CLAUDE.md.