### PR TITLE
refactor: consolidate duplicated adapter / builder / executor code (#850)

### DIFF
--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -16,7 +16,8 @@ import type {
 import {
   discoverCubes,
   suggestQuery,
-  aiValidateQuery
+  aiValidateQuery,
+  getActiveQueryModes
 } from '../server'
 import { QUERY_LANGUAGE_REFERENCE } from '../server/ai/query-schema'
 import { DATE_FILTERING_PROMPT } from '../server/ai/mcp-prompts'
@@ -130,26 +131,9 @@ interface DryRunResponseOptions {
 }
 
 function resolveDryRunMode(query: SemanticQuery): DryRunMode {
-  const activeModes: DryRunMode[] = []
-
-  const hasComparison = query.timeDimensions?.some(td =>
-    td.compareDateRange && td.compareDateRange.length >= 2
-  )
-  if (hasComparison) {
-    activeModes.push('comparison')
-  }
-
-  if (query.funnel && query.funnel.steps?.length >= 2) {
-    activeModes.push('funnel')
-  }
-
-  if (query.flow && query.flow.bindingKey && query.flow.eventDimension) {
-    activeModes.push('flow')
-  }
-
-  if (query.retention && query.retention.bindingKey && query.retention.timeDimension) {
-    activeModes.push('retention')
-  }
+  // Uses the shared mode detector so dry-run reporting stays consistent with
+  // execution routing and validation.
+  const activeModes = getActiveQueryModes(query)
 
   if (activeModes.length === 0) {
     return 'regular'

--- a/src/server/adapters/base-adapter.ts
+++ b/src/server/adapters/base-adapter.ts
@@ -4,7 +4,7 @@
  * Each database adapter must implement these methods to handle SQL dialect differences
  */
 
-import type { SQL, AnyColumn } from 'drizzle-orm'
+import { sql, type SQL, type AnyColumn } from 'drizzle-orm'
 import type { TimeGranularity } from '../types'
 
 /**
@@ -280,38 +280,32 @@ export interface DatabaseAdapter {
  * Provides common functionality that can be shared across database implementations
  */
 export abstract class BaseDatabaseAdapter implements DatabaseAdapter {
+  // ============================================
+  // Engine-specific methods (must be implemented per engine)
+  // ============================================
+
   abstract getEngineType(): 'postgres' | 'mysql' | 'sqlite' | 'singlestore' | 'duckdb' | 'databend' | 'snowflake'
   abstract supportsLateralJoins(): boolean
 
-  // Funnel analysis methods
+  // Funnel analysis methods — interval/date arithmetic differs per engine
   abstract buildIntervalFromISO(duration: string): SQL
   abstract buildTimeDifferenceSeconds(end: SQL, start: SQL): SQL
   abstract buildDateAddInterval(timestamp: SQL, duration: string): SQL
-  abstract buildConditionalAggregation(aggFn: 'count' | 'avg' | 'min' | 'max' | 'sum', expr: SQL | null, condition: SQL): SQL
   abstract buildDateDiffPeriods(startDate: SQL, endDate: SQL, unit: 'day' | 'week' | 'month'): SQL
   abstract buildPeriodSeriesSubquery(maxPeriod: number): SQL
 
+  // Time-dimension truncation (DATE_TRUNC vs DATE_FORMAT vs date() modifiers)
   abstract buildTimeDimension(granularity: TimeGranularity, fieldExpr: AnyColumn | SQL): SQL
-  abstract buildStringCondition(fieldExpr: AnyColumn | SQL, operator: 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'like' | 'notLike' | 'ilike' | 'regex' | 'notRegex', value: string): SQL
+  // Type casting (::type vs CAST(...))
   abstract castToType(fieldExpr: AnyColumn | SQL, targetType: 'timestamp' | 'decimal' | 'integer'): SQL
-  abstract buildAvg(fieldExpr: AnyColumn | SQL): SQL
-  abstract buildCaseWhen(conditions: Array<{ when: SQL; then: any }>, elseValue?: any): SQL
-  abstract buildBooleanLiteral(value: boolean): SQL
-  abstract convertFilterValue(value: any): any
-  abstract prepareDateValue(date: Date): any
-  abstract isTimestampInteger(): boolean
-  abstract convertTimeDimensionResult(value: any): any
+  // Feature flags per engine
   abstract getCapabilities(): DatabaseCapabilities
-  abstract buildStddev(fieldExpr: AnyColumn | SQL, useSample?: boolean): SQL | null
-  abstract buildVariance(fieldExpr: AnyColumn | SQL, useSample?: boolean): SQL | null
+  // Percentile support varies widely (PERCENTILE_CONT / QUANTILE_CONT / unsupported)
   abstract buildPercentile(fieldExpr: AnyColumn | SQL, percentile: number): SQL | null
-  abstract buildWindowFunction(
-    type: WindowFunctionType,
-    fieldExpr: AnyColumn | SQL | null,
-    partitionBy?: (AnyColumn | SQL)[],
-    orderBy?: Array<{ field: AnyColumn | SQL; direction: 'asc' | 'desc' }>,
-    config?: WindowFunctionConfig
-  ): SQL | null
+
+  // ============================================
+  // Shared default implementations (override only where the engine differs)
+  // ============================================
 
   /**
    * Default implementation returns template unchanged
@@ -319,6 +313,237 @@ export abstract class BaseDatabaseAdapter implements DatabaseAdapter {
    */
   preprocessCalculatedTemplate(calculatedSql: string): string {
     return calculatedSql
+  }
+
+  /**
+   * Wrap an aggregate so NULL (empty set) becomes 0.
+   * Default uses COALESCE; engines without COALESCE (MySQL/SQLite) override with IFNULL.
+   */
+  protected nullToZero(expr: SQL): SQL {
+    return sql`COALESCE(${expr}, 0)`
+  }
+
+  /**
+   * Case-insensitive LIKE matching for contains/startsWith/endsWith/ilike.
+   * Default uses native ILIKE (PostgreSQL/DuckDB/Snowflake); engines without ILIKE
+   * (MySQL/SQLite/Databend) override with LOWER()+LIKE.
+   * @param pattern - the LIKE pattern in its original case (already wrapped with % as needed)
+   */
+  protected caseInsensitiveLike(fieldExpr: AnyColumn | SQL, pattern: string, negated: boolean): SQL {
+    return negated
+      ? sql`${fieldExpr} NOT ILIKE ${pattern}`
+      : sql`${fieldExpr} ILIKE ${pattern}`
+  }
+
+  /**
+   * Regular-expression matching. Default uses PostgreSQL's ~* / !~* operators;
+   * each other engine overrides with its own regex syntax (REGEXP, GLOB, regexp_matches, REGEXP_LIKE).
+   */
+  protected regexCondition(fieldExpr: AnyColumn | SQL, value: string, negated: boolean): SQL {
+    return negated
+      ? sql`${fieldExpr} !~* ${value}`
+      : sql`${fieldExpr} ~* ${value}`
+  }
+
+  /**
+   * Build a string matching condition. The case-insensitive and regex families are
+   * delegated to the caseInsensitiveLike()/regexCondition() hooks; plain LIKE/NOT LIKE
+   * are identical across all engines.
+   */
+  buildStringCondition(
+    fieldExpr: AnyColumn | SQL,
+    operator: 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'like' | 'notLike' | 'ilike' | 'regex' | 'notRegex',
+    value: string
+  ): SQL {
+    switch (operator) {
+      case 'contains':
+        return this.caseInsensitiveLike(fieldExpr, `%${value}%`, false)
+      case 'notContains':
+        return this.caseInsensitiveLike(fieldExpr, `%${value}%`, true)
+      case 'startsWith':
+        return this.caseInsensitiveLike(fieldExpr, `${value}%`, false)
+      case 'endsWith':
+        return this.caseInsensitiveLike(fieldExpr, `%${value}`, false)
+      case 'like':
+        return sql`${fieldExpr} LIKE ${value}`
+      case 'notLike':
+        return sql`${fieldExpr} NOT LIKE ${value}`
+      case 'ilike':
+        return this.caseInsensitiveLike(fieldExpr, value, false)
+      case 'regex':
+        return this.regexCondition(fieldExpr, value, false)
+      case 'notRegex':
+        return this.regexCondition(fieldExpr, value, true)
+      default:
+        throw new Error(`Unsupported string operator: ${operator}`)
+    }
+  }
+
+  /**
+   * Build conditional aggregation. Default uses portable CASE WHEN
+   * (MySQL/SQLite/Databend/Snowflake); PostgreSQL/DuckDB override with the FILTER clause.
+   */
+  buildConditionalAggregation(
+    aggFn: 'count' | 'avg' | 'min' | 'max' | 'sum',
+    expr: SQL | null,
+    condition: SQL
+  ): SQL {
+    const fnName = aggFn.toUpperCase()
+    if (aggFn === 'count' && !expr) {
+      return sql`${sql.raw(fnName)}(CASE WHEN ${condition} THEN 1 END)`
+    }
+    return sql`${sql.raw(fnName)}(CASE WHEN ${condition} THEN ${expr} END)`
+  }
+
+  /**
+   * Build AVG with null-to-zero handling (COALESCE/IFNULL via nullToZero()).
+   */
+  buildAvg(fieldExpr: AnyColumn | SQL): SQL {
+    return this.nullToZero(sql`AVG(${fieldExpr})`)
+  }
+
+  /**
+   * Build CASE WHEN conditional expression.
+   * SQLite overrides this to handle embedded SQL objects in THEN/ELSE.
+   */
+  buildCaseWhen(conditions: Array<{ when: SQL; then: any }>, elseValue?: any): SQL {
+    const cases = conditions.map(c => sql`WHEN ${c.when} THEN ${c.then}`).reduce((acc, curr) => sql`${acc} ${curr}`)
+
+    if (elseValue !== undefined) {
+      return sql`CASE ${cases} ELSE ${elseValue} END`
+    }
+    return sql`CASE ${cases} END`
+  }
+
+  /**
+   * Build boolean literal. Default uses TRUE/FALSE keywords; SQLite overrides with 1/0.
+   */
+  buildBooleanLiteral(value: boolean): SQL {
+    return value ? sql`TRUE` : sql`FALSE`
+  }
+
+  /**
+   * Convert filter values to database-compatible types.
+   * Default is a pass-through; SQLite overrides to handle booleans/dates as integers.
+   */
+  convertFilterValue(value: any): any {
+    return value
+  }
+
+  /**
+   * Prepare a Date for storage. Default passes the Date through (native timestamps);
+   * SQLite overrides to convert to integer milliseconds.
+   */
+  prepareDateValue(date: Date): any {
+    return date
+  }
+
+  /**
+   * Whether timestamps are stored as integers. Default false; SQLite overrides to true.
+   */
+  isTimestampInteger(): boolean {
+    return false
+  }
+
+  /**
+   * Convert a time-dimension result value. Default is a pass-through.
+   */
+  convertTimeDimensionResult(value: any): any {
+    return value
+  }
+
+  /**
+   * Build STDDEV aggregation. Default uses STDDEV_POP/STDDEV_SAMP with null-to-zero.
+   * Engines without native STDDEV (SQLite) override to return null.
+   */
+  buildStddev(fieldExpr: AnyColumn | SQL, useSample = false): SQL | null {
+    const fn = useSample ? 'STDDEV_SAMP' : 'STDDEV_POP'
+    return this.nullToZero(sql`${sql.raw(fn)}(${fieldExpr})`)
+  }
+
+  /**
+   * Build VARIANCE aggregation. Default uses VAR_POP/VAR_SAMP with null-to-zero.
+   * SQLite overrides to null; Databend overrides to a COVAR-based workaround.
+   */
+  buildVariance(fieldExpr: AnyColumn | SQL, useSample = false): SQL | null {
+    const fn = useSample ? 'VAR_SAMP' : 'VAR_POP'
+    return this.nullToZero(sql`${sql.raw(fn)}(${fieldExpr})`)
+  }
+
+  /**
+   * Build a window function expression. Identical across all supported engines
+   * (standard SQL:2003 window syntax), so it lives here as a shared default.
+   */
+  buildWindowFunction(
+    type: WindowFunctionType,
+    fieldExpr: AnyColumn | SQL | null,
+    partitionBy?: (AnyColumn | SQL)[],
+    orderBy?: Array<{ field: AnyColumn | SQL; direction: 'asc' | 'desc' }>,
+    config?: WindowFunctionConfig
+  ): SQL | null {
+    // Build OVER clause components
+    const partitionClause = partitionBy && partitionBy.length > 0
+      ? sql`PARTITION BY ${sql.join(partitionBy, sql`, `)}`
+      : sql``
+
+    const orderClause = orderBy && orderBy.length > 0
+      ? sql`ORDER BY ${sql.join(orderBy.map(o =>
+          o.direction === 'desc' ? sql`${o.field} DESC` : sql`${o.field} ASC`
+        ), sql`, `)}`
+      : sql``
+
+    // Build frame clause if specified
+    let frameClause = sql``
+    if (config?.frame) {
+      const { type: frameType, start, end } = config.frame
+      const frameTypeStr = frameType.toUpperCase()
+
+      const startStr = start === 'unbounded' ? 'UNBOUNDED PRECEDING'
+        : typeof start === 'number' ? `${start} PRECEDING`
+        : 'CURRENT ROW'
+
+      const endStr = end === 'unbounded' ? 'UNBOUNDED FOLLOWING'
+        : end === 'current' ? 'CURRENT ROW'
+        : typeof end === 'number' ? `${end} FOLLOWING`
+        : 'CURRENT ROW'
+
+      frameClause = sql`${sql.raw(frameTypeStr)} BETWEEN ${sql.raw(startStr)} AND ${sql.raw(endStr)}`
+    }
+
+    // Combine OVER clause
+    const overParts: SQL[] = []
+    if (partitionBy && partitionBy.length > 0) overParts.push(partitionClause)
+    if (orderBy && orderBy.length > 0) overParts.push(orderClause)
+    if (config?.frame) overParts.push(frameClause)
+
+    const overContent = overParts.length > 0 ? sql.join(overParts, sql` `) : sql``
+    const over = sql`OVER (${overContent})`
+
+    // Build the window function based on type
+    switch (type) {
+      case 'lag':
+        return sql`LAG(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
+      case 'lead':
+        return sql`LEAD(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
+      case 'rank':
+        return sql`RANK() ${over}`
+      case 'denseRank':
+        return sql`DENSE_RANK() ${over}`
+      case 'rowNumber':
+        return sql`ROW_NUMBER() ${over}`
+      case 'ntile':
+        return sql`NTILE(${config?.nTile ?? 4}) ${over}`
+      case 'firstValue':
+        return sql`FIRST_VALUE(${fieldExpr}) ${over}`
+      case 'lastValue':
+        return sql`LAST_VALUE(${fieldExpr}) ${over}`
+      case 'movingAvg':
+        return sql`AVG(${fieldExpr}) ${over}`
+      case 'movingSum':
+        return sql`SUM(${fieldExpr}) ${over}`
+      default:
+        throw new Error(`Unsupported window function: ${type}`)
+    }
   }
 
   /**

--- a/src/server/adapters/databend-adapter.ts
+++ b/src/server/adapters/databend-adapter.ts
@@ -3,11 +3,15 @@
  * Implements Databend-specific SQL generation for time dimensions, string matching, and type casting
  * Databend uses pgcore (extends PgDialect) so is largely PostgreSQL-compatible
  * Key differences: no ILIKE, uses CASE WHEN for conditional aggregation, TIMESTAMPDIFF for time diffs
+ *
+ * Inherits shared defaults from BaseDatabaseAdapter (CASE WHEN conditional aggregation,
+ * COALESCE null-handling, standard window functions). Overrides the string-matching hooks
+ * (no native ILIKE) and VARIANCE (no native VAR_POP/VAR_SAMP).
  */
 
 import { sql, type SQL, type AnyColumn } from 'drizzle-orm'
 import type { TimeGranularity } from '../types'
-import { BaseDatabaseAdapter, type DatabaseCapabilities, type WindowFunctionType, type WindowFunctionConfig } from './base-adapter'
+import { BaseDatabaseAdapter, type DatabaseCapabilities } from './base-adapter'
 
 export class DatabendAdapter extends BaseDatabaseAdapter {
   getEngineType(): 'databend' {
@@ -68,22 +72,6 @@ export class DatabendAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build Databend conditional aggregation using CASE WHEN
-   * FILTER clause support is uncertain in Databend, so use CASE WHEN for safety
-   */
-  buildConditionalAggregation(
-    aggFn: 'count' | 'avg' | 'min' | 'max' | 'sum',
-    expr: SQL | null,
-    condition: SQL
-  ): SQL {
-    const fnName = aggFn.toUpperCase()
-    if (aggFn === 'count' && !expr) {
-      return sql`${sql.raw(fnName)}(CASE WHEN ${condition} THEN 1 END)`
-    }
-    return sql`${sql.raw(fnName)}(CASE WHEN ${condition} THEN ${expr} END)`
-  }
-
-  /**
    * Build Databend date difference in periods using DATE_DIFF
    */
   buildDateDiffPeriods(startDate: SQL, endDate: SQL, unit: 'day' | 'week' | 'month'): SQL {
@@ -100,7 +88,7 @@ export class DatabendAdapter extends BaseDatabaseAdapter {
 
   /**
    * Build Databend time dimension using DATE_TRUNC function
-   * Databend supports DATE_TRUNC with quoted granularity like PostgreSQL
+   * Databend supports DATE_TRUNC with unquoted granularity keywords
    */
   buildTimeDimension(granularity: TimeGranularity, fieldExpr: AnyColumn | SQL): SQL {
     switch (granularity) {
@@ -126,32 +114,21 @@ export class DatabendAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build Databend string matching conditions using LOWER+LIKE fallback
-   * Databend does not support ILIKE
+   * Databend has no ILIKE — use LOWER()+LIKE with SQL-side LOWER() on the pattern.
    */
-  buildStringCondition(fieldExpr: AnyColumn | SQL, operator: 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'like' | 'notLike' | 'ilike' | 'regex' | 'notRegex', value: string): SQL {
-    switch (operator) {
-      case 'contains':
-        return sql`LOWER(${fieldExpr}) LIKE LOWER(${`%${value}%`})`
-      case 'notContains':
-        return sql`LOWER(${fieldExpr}) NOT LIKE LOWER(${`%${value}%`})`
-      case 'startsWith':
-        return sql`LOWER(${fieldExpr}) LIKE LOWER(${`${value}%`})`
-      case 'endsWith':
-        return sql`LOWER(${fieldExpr}) LIKE LOWER(${`%${value}`})`
-      case 'like':
-        return sql`${fieldExpr} LIKE ${value}`
-      case 'notLike':
-        return sql`${fieldExpr} NOT LIKE ${value}`
-      case 'ilike':
-        return sql`LOWER(${fieldExpr}) LIKE LOWER(${value})`
-      case 'regex':
-        return sql`${fieldExpr} REGEXP ${value}`
-      case 'notRegex':
-        return sql`NOT (${fieldExpr} REGEXP ${value})`
-      default:
-        throw new Error(`Unsupported string operator: ${operator}`)
-    }
+  protected caseInsensitiveLike(fieldExpr: AnyColumn | SQL, pattern: string, negated: boolean): SQL {
+    return negated
+      ? sql`LOWER(${fieldExpr}) NOT LIKE LOWER(${pattern})`
+      : sql`LOWER(${fieldExpr}) LIKE LOWER(${pattern})`
+  }
+
+  /**
+   * Databend regex matching uses the REGEXP operator
+   */
+  protected regexCondition(fieldExpr: AnyColumn | SQL, value: string, negated: boolean): SQL {
+    return negated
+      ? sql`NOT (${fieldExpr} REGEXP ${value})`
+      : sql`${fieldExpr} REGEXP ${value}`
   }
 
   /**
@@ -169,62 +146,6 @@ export class DatabendAdapter extends BaseDatabaseAdapter {
       default:
         throw new Error(`Unsupported cast type: ${targetType}`)
     }
-  }
-
-  /**
-   * Build Databend AVG aggregation with COALESCE for NULL handling
-   */
-  buildAvg(fieldExpr: AnyColumn | SQL): SQL {
-    return sql`COALESCE(AVG(${fieldExpr}), 0)`
-  }
-
-  /**
-   * Build Databend CASE WHEN conditional expression
-   */
-  buildCaseWhen(conditions: Array<{ when: SQL; then: any }>, elseValue?: any): SQL {
-    const cases = conditions.map(c => sql`WHEN ${c.when} THEN ${c.then}`).reduce((acc, curr) => sql`${acc} ${curr}`)
-
-    if (elseValue !== undefined) {
-      return sql`CASE ${cases} ELSE ${elseValue} END`
-    }
-    return sql`CASE ${cases} END`
-  }
-
-  /**
-   * Build Databend boolean literal
-   * Databend uses TRUE/FALSE keywords
-   */
-  buildBooleanLiteral(value: boolean): SQL {
-    return value ? sql`TRUE` : sql`FALSE`
-  }
-
-  /**
-   * Convert filter values - Databend uses native types
-   */
-  convertFilterValue(value: any): any {
-    return value
-  }
-
-  /**
-   * Prepare date value for Databend
-   * Databend accepts Date objects directly
-   */
-  prepareDateValue(date: Date): any {
-    return date
-  }
-
-  /**
-   * Databend stores timestamps as native timestamp types
-   */
-  isTimestampInteger(): boolean {
-    return false
-  }
-
-  /**
-   * Databend time dimensions already return proper values
-   */
-  convertTimeDimensionResult(value: any): any {
-    return value
   }
 
   // ============================================
@@ -249,14 +170,6 @@ export class DatabendAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build Databend STDDEV aggregation
-   */
-  buildStddev(fieldExpr: AnyColumn | SQL, useSample = false): SQL {
-    const fn = useSample ? 'STDDEV_SAMP' : 'STDDEV_POP'
-    return sql`COALESCE(${sql.raw(fn)}(${fieldExpr}), 0)`
-  }
-
-  /**
    * Build Databend VARIANCE aggregation
    * Databend doesn't have VAR_POP/VAR_SAMP, but COVAR_POP(x,x) = VAR_POP(x)
    * and COVAR_SAMP(x,x) = VAR_SAMP(x) mathematically
@@ -272,81 +185,5 @@ export class DatabendAdapter extends BaseDatabaseAdapter {
    */
   buildPercentile(_fieldExpr: AnyColumn | SQL, _percentile: number): SQL {
     throw new Error('Percentile functions are not yet supported for Databend')
-  }
-
-  /**
-   * Build Databend window function expression
-   * Databend has full window function support
-   */
-  buildWindowFunction(
-    type: WindowFunctionType,
-    fieldExpr: AnyColumn | SQL | null,
-    partitionBy?: (AnyColumn | SQL)[],
-    orderBy?: Array<{ field: AnyColumn | SQL; direction: 'asc' | 'desc' }>,
-    config?: WindowFunctionConfig
-  ): SQL {
-    // Build OVER clause components
-    const partitionClause = partitionBy && partitionBy.length > 0
-      ? sql`PARTITION BY ${sql.join(partitionBy, sql`, `)}`
-      : sql``
-
-    const orderClause = orderBy && orderBy.length > 0
-      ? sql`ORDER BY ${sql.join(orderBy.map(o =>
-          o.direction === 'desc' ? sql`${o.field} DESC` : sql`${o.field} ASC`
-        ), sql`, `)}`
-      : sql``
-
-    // Build frame clause if specified
-    let frameClause = sql``
-    if (config?.frame) {
-      const { type: frameType, start, end } = config.frame
-      const frameTypeStr = frameType.toUpperCase()
-
-      const startStr = start === 'unbounded' ? 'UNBOUNDED PRECEDING'
-        : typeof start === 'number' ? `${start} PRECEDING`
-        : 'CURRENT ROW'
-
-      const endStr = end === 'unbounded' ? 'UNBOUNDED FOLLOWING'
-        : end === 'current' ? 'CURRENT ROW'
-        : typeof end === 'number' ? `${end} FOLLOWING`
-        : 'CURRENT ROW'
-
-      frameClause = sql`${sql.raw(frameTypeStr)} BETWEEN ${sql.raw(startStr)} AND ${sql.raw(endStr)}`
-    }
-
-    // Combine OVER clause
-    const overParts: SQL[] = []
-    if (partitionBy && partitionBy.length > 0) overParts.push(partitionClause)
-    if (orderBy && orderBy.length > 0) overParts.push(orderClause)
-    if (config?.frame) overParts.push(frameClause)
-
-    const overContent = overParts.length > 0 ? sql.join(overParts, sql` `) : sql``
-    const over = sql`OVER (${overContent})`
-
-    // Build the window function based on type
-    switch (type) {
-      case 'lag':
-        return sql`LAG(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'lead':
-        return sql`LEAD(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'rank':
-        return sql`RANK() ${over}`
-      case 'denseRank':
-        return sql`DENSE_RANK() ${over}`
-      case 'rowNumber':
-        return sql`ROW_NUMBER() ${over}`
-      case 'ntile':
-        return sql`NTILE(${config?.nTile ?? 4}) ${over}`
-      case 'firstValue':
-        return sql`FIRST_VALUE(${fieldExpr}) ${over}`
-      case 'lastValue':
-        return sql`LAST_VALUE(${fieldExpr}) ${over}`
-      case 'movingAvg':
-        return sql`AVG(${fieldExpr}) ${over}`
-      case 'movingSum':
-        return sql`SUM(${fieldExpr}) ${over}`
-      default:
-        throw new Error(`Unsupported window function: ${type}`)
-    }
   }
 }

--- a/src/server/adapters/duckdb-adapter.ts
+++ b/src/server/adapters/duckdb-adapter.ts
@@ -2,11 +2,14 @@
  * DuckDB Database Adapter
  * Implements DuckDB-specific SQL generation for time dimensions, string matching, and type casting
  * DuckDB is largely PostgreSQL-compatible but has some differences in funnel functions and advanced features
+ *
+ * Inherits shared defaults from BaseDatabaseAdapter (ILIKE string matching, COALESCE
+ * null-handling, standard window functions, etc.). Only DuckDB-specific SQL is here.
  */
 
 import { sql, type SQL, type AnyColumn } from 'drizzle-orm'
 import type { TimeGranularity } from '../types'
-import { BaseDatabaseAdapter, type DatabaseCapabilities, type WindowFunctionType, type WindowFunctionConfig } from './base-adapter'
+import { BaseDatabaseAdapter, type DatabaseCapabilities } from './base-adapter'
 
 export class DuckDBAdapter extends BaseDatabaseAdapter {
   getEngineType(): 'duckdb' {
@@ -63,9 +66,8 @@ export class DuckDBAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build DuckDB conditional aggregation using CASE WHEN
-   * DuckDB supports FILTER clause, but CASE WHEN provides broader compatibility
-   * Using FILTER clause as DuckDB does support it
+   * Build DuckDB conditional aggregation using the FILTER clause
+   * DuckDB supports the standard SQL FILTER clause like PostgreSQL
    */
   buildConditionalAggregation(
     aggFn: 'count' | 'avg' | 'min' | 'max' | 'sum',
@@ -124,32 +126,12 @@ export class DuckDBAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build DuckDB string matching conditions using ILIKE (case-insensitive)
-   * DuckDB supports ILIKE like PostgreSQL
+   * DuckDB uses function-style regex matching: regexp_matches(field, pattern)
    */
-  buildStringCondition(fieldExpr: AnyColumn | SQL, operator: 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'like' | 'notLike' | 'ilike' | 'regex' | 'notRegex', value: string): SQL {
-    switch (operator) {
-      case 'contains':
-        return sql`${fieldExpr} ILIKE ${`%${value}%`}`
-      case 'notContains':
-        return sql`${fieldExpr} NOT ILIKE ${`%${value}%`}`
-      case 'startsWith':
-        return sql`${fieldExpr} ILIKE ${`${value}%`}`
-      case 'endsWith':
-        return sql`${fieldExpr} ILIKE ${`%${value}`}`
-      case 'like':
-        return sql`${fieldExpr} LIKE ${value}`
-      case 'notLike':
-        return sql`${fieldExpr} NOT LIKE ${value}`
-      case 'ilike':
-        return sql`${fieldExpr} ILIKE ${value}`
-      case 'regex':
-        return sql`regexp_matches(${fieldExpr}, ${value})`
-      case 'notRegex':
-        return sql`NOT regexp_matches(${fieldExpr}, ${value})`
-      default:
-        throw new Error(`Unsupported string operator: ${operator}`)
-    }
+  protected regexCondition(fieldExpr: AnyColumn | SQL, value: string, negated: boolean): SQL {
+    return negated
+      ? sql`NOT regexp_matches(${fieldExpr}, ${value})`
+      : sql`regexp_matches(${fieldExpr}, ${value})`
   }
 
   /**
@@ -167,62 +149,6 @@ export class DuckDBAdapter extends BaseDatabaseAdapter {
       default:
         throw new Error(`Unsupported cast type: ${targetType}`)
     }
-  }
-
-  /**
-   * Build DuckDB AVG aggregation with COALESCE for NULL handling
-   */
-  buildAvg(fieldExpr: AnyColumn | SQL): SQL {
-    return sql`COALESCE(AVG(${fieldExpr}), 0)`
-  }
-
-  /**
-   * Build DuckDB CASE WHEN conditional expression
-   */
-  buildCaseWhen(conditions: Array<{ when: SQL; then: any }>, elseValue?: any): SQL {
-    const cases = conditions.map(c => sql`WHEN ${c.when} THEN ${c.then}`).reduce((acc, curr) => sql`${acc} ${curr}`)
-
-    if (elseValue !== undefined) {
-      return sql`CASE ${cases} ELSE ${elseValue} END`
-    }
-    return sql`CASE ${cases} END`
-  }
-
-  /**
-   * Build DuckDB boolean literal
-   * DuckDB uses TRUE/FALSE keywords
-   */
-  buildBooleanLiteral(value: boolean): SQL {
-    return value ? sql`TRUE` : sql`FALSE`
-  }
-
-  /**
-   * Convert filter values - DuckDB uses native types
-   */
-  convertFilterValue(value: any): any {
-    return value
-  }
-
-  /**
-   * Prepare date value for DuckDB
-   * DuckDB accepts Date objects directly
-   */
-  prepareDateValue(date: Date): any {
-    return date
-  }
-
-  /**
-   * DuckDB stores timestamps as native timestamp types
-   */
-  isTimestampInteger(): boolean {
-    return false
-  }
-
-  /**
-   * DuckDB time dimensions already return proper values
-   */
-  convertTimeDimensionResult(value: any): any {
-    return value
   }
 
   // ============================================
@@ -251,105 +177,11 @@ export class DuckDBAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build DuckDB STDDEV aggregation
-   * Uses STDDEV_POP for population, STDDEV_SAMP for sample
-   */
-  buildStddev(fieldExpr: AnyColumn | SQL, useSample = false): SQL {
-    const fn = useSample ? 'STDDEV_SAMP' : 'STDDEV_POP'
-    return sql`COALESCE(${sql.raw(fn)}(${fieldExpr}), 0)`
-  }
-
-  /**
-   * Build DuckDB VARIANCE aggregation
-   * Uses VAR_POP for population, VAR_SAMP for sample
-   */
-  buildVariance(fieldExpr: AnyColumn | SQL, useSample = false): SQL {
-    const fn = useSample ? 'VAR_SAMP' : 'VAR_POP'
-    return sql`COALESCE(${sql.raw(fn)}(${fieldExpr}), 0)`
-  }
-
-  /**
    * Build DuckDB PERCENTILE aggregation
    * DuckDB uses QUANTILE_CONT instead of PERCENTILE_CONT
    */
   buildPercentile(fieldExpr: AnyColumn | SQL, percentile: number): SQL {
     const pct = percentile / 100
     return sql`QUANTILE_CONT(${fieldExpr}, ${pct})`
-  }
-
-  /**
-   * Build DuckDB window function expression
-   * DuckDB has full window function support
-   */
-  buildWindowFunction(
-    type: WindowFunctionType,
-    fieldExpr: AnyColumn | SQL | null,
-    partitionBy?: (AnyColumn | SQL)[],
-    orderBy?: Array<{ field: AnyColumn | SQL; direction: 'asc' | 'desc' }>,
-    config?: WindowFunctionConfig
-  ): SQL {
-    // Build OVER clause components
-    const partitionClause = partitionBy && partitionBy.length > 0
-      ? sql`PARTITION BY ${sql.join(partitionBy, sql`, `)}`
-      : sql``
-
-    const orderClause = orderBy && orderBy.length > 0
-      ? sql`ORDER BY ${sql.join(orderBy.map(o =>
-          o.direction === 'desc' ? sql`${o.field} DESC` : sql`${o.field} ASC`
-        ), sql`, `)}`
-      : sql``
-
-    // Build frame clause if specified
-    let frameClause = sql``
-    if (config?.frame) {
-      const { type: frameType, start, end } = config.frame
-      const frameTypeStr = frameType.toUpperCase()
-
-      const startStr = start === 'unbounded' ? 'UNBOUNDED PRECEDING'
-        : typeof start === 'number' ? `${start} PRECEDING`
-        : 'CURRENT ROW'
-
-      const endStr = end === 'unbounded' ? 'UNBOUNDED FOLLOWING'
-        : end === 'current' ? 'CURRENT ROW'
-        : typeof end === 'number' ? `${end} FOLLOWING`
-        : 'CURRENT ROW'
-
-      frameClause = sql`${sql.raw(frameTypeStr)} BETWEEN ${sql.raw(startStr)} AND ${sql.raw(endStr)}`
-    }
-
-    // Combine OVER clause
-    const overParts: SQL[] = []
-    if (partitionBy && partitionBy.length > 0) overParts.push(partitionClause)
-    if (orderBy && orderBy.length > 0) overParts.push(orderClause)
-    if (config?.frame) overParts.push(frameClause)
-
-    const overContent = overParts.length > 0 ? sql.join(overParts, sql` `) : sql``
-    const over = sql`OVER (${overContent})`
-
-    // Build the window function based on type
-    switch (type) {
-      case 'lag':
-        return sql`LAG(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'lead':
-        return sql`LEAD(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'rank':
-        return sql`RANK() ${over}`
-      case 'denseRank':
-        return sql`DENSE_RANK() ${over}`
-      case 'rowNumber':
-        return sql`ROW_NUMBER() ${over}`
-      case 'ntile':
-        return sql`NTILE(${config?.nTile ?? 4}) ${over}`
-      case 'firstValue':
-        return sql`FIRST_VALUE(${fieldExpr}) ${over}`
-      case 'lastValue':
-        return sql`LAST_VALUE(${fieldExpr}) ${over}`
-      case 'movingAvg':
-        return sql`AVG(${fieldExpr}) ${over}`
-      case 'movingSum':
-        return sql`SUM(${fieldExpr}) ${over}`
-      default:
-        throw new Error(`Unsupported window function: ${type}`)
-    }
   }
 }

--- a/src/server/adapters/mysql-adapter.ts
+++ b/src/server/adapters/mysql-adapter.ts
@@ -1,12 +1,16 @@
 /**
- * MySQL Database Adapter  
+ * MySQL Database Adapter
  * Implements MySQL-specific SQL generation for time dimensions, string matching, and type casting
  * Provides MySQL equivalents to PostgreSQL functions
+ *
+ * Inherits shared defaults from BaseDatabaseAdapter (CASE WHEN conditional aggregation,
+ * standard window functions). Overrides null-handling (IFNULL), the string-matching hooks
+ * (no native ILIKE), and the percentile/cast methods.
  */
 
 import { sql, type SQL, type AnyColumn } from 'drizzle-orm'
 import type { TimeGranularity } from '../types'
-import { BaseDatabaseAdapter, type DatabaseCapabilities, type WindowFunctionType, type WindowFunctionConfig } from './base-adapter'
+import { BaseDatabaseAdapter, type DatabaseCapabilities } from './base-adapter'
 
 export class MySQLAdapter extends BaseDatabaseAdapter {
   getEngineType(): 'mysql' | 'singlestore' {
@@ -26,23 +30,10 @@ export class MySQLAdapter extends BaseDatabaseAdapter {
 
   /**
    * Build MySQL INTERVAL from ISO 8601 duration
-   * MySQL uses DATE_ADD with INTERVAL syntax but intervals must be added separately
-   * For simplicity, we convert to seconds for consistent handling
+   * MySQL has no standalone interval literal usable in arithmetic, so we convert
+   * to total seconds for consistent handling.
    */
   buildIntervalFromISO(duration: string): SQL {
-    const parsed = this.parseISODuration(duration)
-    const parts: string[] = []
-
-    // MySQL allows multiple interval additions but for simplicity convert to a single unit
-    // We'll use the most significant unit
-    if (parsed.years) parts.push(`${parsed.years} YEAR`)
-    if (parsed.months) parts.push(`${parsed.months} MONTH`)
-    if (parsed.days) parts.push(`${parsed.days} DAY`)
-    if (parsed.hours) parts.push(`${parsed.hours} HOUR`)
-    if (parsed.minutes) parts.push(`${parsed.minutes} MINUTE`)
-    if (parsed.seconds) parts.push(`${parsed.seconds} SECOND`)
-
-    // For MySQL, return the interval as seconds for consistent arithmetic
     const totalSeconds = this.durationToSeconds(duration)
     return sql`${totalSeconds}`
   }
@@ -57,7 +48,7 @@ export class MySQLAdapter extends BaseDatabaseAdapter {
 
   /**
    * Build MySQL timestamp + interval expression
-   * Uses DATE_ADD function
+   * Uses a chain of DATE_ADD calls, one per duration component
    */
   buildDateAddInterval(timestamp: SQL, duration: string): SQL {
     const parsed = this.parseISODuration(duration)
@@ -74,25 +65,6 @@ export class MySQLAdapter extends BaseDatabaseAdapter {
     if (parsed.seconds) result = sql`DATE_ADD(${result}, INTERVAL ${parsed.seconds} SECOND)`
 
     return result
-  }
-
-  /**
-   * Build MySQL conditional aggregation using CASE WHEN
-   * MySQL doesn't support FILTER clause, so we use CASE WHEN pattern
-   * Example: AVG(CASE WHEN step_1_time IS NOT NULL THEN time_diff END)
-   */
-  buildConditionalAggregation(
-    aggFn: 'count' | 'avg' | 'min' | 'max' | 'sum',
-    expr: SQL | null,
-    condition: SQL
-  ): SQL {
-    const fnName = aggFn.toUpperCase()
-    if (aggFn === 'count' && !expr) {
-      // COUNT(*) with condition -> COUNT(CASE WHEN condition THEN 1 END)
-      return sql`COUNT(CASE WHEN ${condition} THEN 1 END)`
-    }
-    // AVG/MIN/MAX/SUM -> AGG(CASE WHEN condition THEN expr END)
-    return sql`${sql.raw(fnName)}(CASE WHEN ${condition} THEN ${expr} END)`
   }
 
   /**
@@ -129,7 +101,7 @@ export class MySQLAdapter extends BaseDatabaseAdapter {
     const formatMap: Record<TimeGranularity, string> = {
       year: '%Y-01-01 00:00:00',
       quarter: '%Y-%q-01 00:00:00', // %q gives quarter (1,2,3,4), but we need to map this properly
-      month: '%Y-%m-01 00:00:00', 
+      month: '%Y-%m-01 00:00:00',
       week: '%Y-%u-01 00:00:00', // %u gives week of year
       day: '%Y-%m-%d 00:00:00',
       hour: '%Y-%m-%d %H:00:00',
@@ -160,34 +132,22 @@ export class MySQLAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build MySQL string matching conditions using LIKE
-   * MySQL LIKE is case-insensitive by default (depending on collation)
-   * For guaranteed case-insensitive matching, we use LOWER() functions
+   * MySQL has no ILIKE — use LOWER()+LIKE with the pattern lowercased in JS.
    */
-  buildStringCondition(fieldExpr: AnyColumn | SQL, operator: 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'like' | 'notLike' | 'ilike' | 'regex' | 'notRegex', value: string): SQL {
-    switch (operator) {
-      case 'contains':
-        return sql`LOWER(${fieldExpr}) LIKE ${`%${value.toLowerCase()}%`}`
-      case 'notContains':
-        return sql`LOWER(${fieldExpr}) NOT LIKE ${`%${value.toLowerCase()}%`}`
-      case 'startsWith':
-        return sql`LOWER(${fieldExpr}) LIKE ${`${value.toLowerCase()}%`}`
-      case 'endsWith':
-        return sql`LOWER(${fieldExpr}) LIKE ${`%${value.toLowerCase()}`}`
-      case 'like':
-        return sql`${fieldExpr} LIKE ${value}`
-      case 'notLike':
-        return sql`${fieldExpr} NOT LIKE ${value}`
-      case 'ilike':
-        // MySQL doesn't have ILIKE, use LOWER() + LIKE for case-insensitive
-        return sql`LOWER(${fieldExpr}) LIKE ${value.toLowerCase()}`
-      case 'regex':
-        return sql`${fieldExpr} REGEXP ${value}`
-      case 'notRegex':
-        return sql`${fieldExpr} NOT REGEXP ${value}`
-      default:
-        throw new Error(`Unsupported string operator: ${operator}`)
-    }
+  protected caseInsensitiveLike(fieldExpr: AnyColumn | SQL, pattern: string, negated: boolean): SQL {
+    const lowered = pattern.toLowerCase()
+    return negated
+      ? sql`LOWER(${fieldExpr}) NOT LIKE ${lowered}`
+      : sql`LOWER(${fieldExpr}) LIKE ${lowered}`
+  }
+
+  /**
+   * MySQL regex matching uses the REGEXP operator
+   */
+  protected regexCondition(fieldExpr: AnyColumn | SQL, value: string, negated: boolean): SQL {
+    return negated
+      ? sql`${fieldExpr} NOT REGEXP ${value}`
+      : sql`${fieldExpr} REGEXP ${value}`
   }
 
   /**
@@ -207,65 +167,12 @@ export class MySQLAdapter extends BaseDatabaseAdapter {
     }
   }
 
-
   /**
-   * Build MySQL AVG aggregation with IFNULL for NULL handling
-   * MySQL AVG returns NULL for empty sets, using IFNULL for consistency
+   * MySQL AVG/STDDEV/VARIANCE use IFNULL (no COALESCE-for-zero idiom mismatch,
+   * but IFNULL is the MySQL-idiomatic null guard).
    */
-  buildAvg(fieldExpr: AnyColumn | SQL): SQL {
-    return sql`IFNULL(AVG(${fieldExpr}), 0)`
-  }
-
-
-  /**
-   * Build MySQL CASE WHEN conditional expression
-   */
-  buildCaseWhen(conditions: Array<{ when: SQL; then: any }>, elseValue?: any): SQL {
-    const cases = conditions.map(c => sql`WHEN ${c.when} THEN ${c.then}`).reduce((acc, curr) => sql`${acc} ${curr}`)
-    
-    if (elseValue !== undefined) {
-      return sql`CASE ${cases} ELSE ${elseValue} END`
-    }
-    return sql`CASE ${cases} END`
-  }
-
-  /**
-   * Build MySQL boolean literal
-   * MySQL uses TRUE/FALSE keywords (equivalent to 1/0)
-   */
-  buildBooleanLiteral(value: boolean): SQL {
-    return value ? sql`TRUE` : sql`FALSE`
-  }
-
-  /**
-   * Convert filter values - MySQL uses native types
-   * No conversion needed for MySQL
-   */
-  convertFilterValue(value: any): any {
-    return value
-  }
-
-  /**
-   * Prepare date value for MySQL
-   * MySQL accepts Date objects directly
-   */
-  prepareDateValue(date: Date): any {
-    return date
-  }
-
-  /**
-   * MySQL stores timestamps as native timestamp types
-   */
-  isTimestampInteger(): boolean {
-    return false
-  }
-
-  /**
-   * MySQL time dimensions already return proper values
-   * No conversion needed
-   */
-  convertTimeDimensionResult(value: any): any {
-    return value
+  protected nullToZero(expr: SQL): SQL {
+    return sql`IFNULL(${expr}, 0)`
   }
 
   // ============================================
@@ -291,24 +198,6 @@ export class MySQLAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build MySQL STDDEV aggregation
-   * Uses STDDEV_POP for population, STDDEV_SAMP for sample
-   */
-  buildStddev(fieldExpr: AnyColumn | SQL, useSample = false): SQL {
-    const fn = useSample ? 'STDDEV_SAMP' : 'STDDEV_POP'
-    return sql`IFNULL(${sql.raw(fn)}(${fieldExpr}), 0)`
-  }
-
-  /**
-   * Build MySQL VARIANCE aggregation
-   * Uses VAR_POP for population, VAR_SAMP for sample
-   */
-  buildVariance(fieldExpr: AnyColumn | SQL, useSample = false): SQL {
-    const fn = useSample ? 'VAR_SAMP' : 'VAR_POP'
-    return sql`IFNULL(${sql.raw(fn)}(${fieldExpr}), 0)`
-  }
-
-  /**
    * MySQL does not support PERCENTILE_CONT
    * Returns null for graceful degradation
    */
@@ -316,81 +205,5 @@ export class MySQLAdapter extends BaseDatabaseAdapter {
     // MySQL doesn't have native PERCENTILE_CONT
     // Return null to trigger graceful degradation
     return null
-  }
-
-  /**
-   * Build MySQL window function expression
-   * MySQL 8.0+ has full window function support
-   */
-  buildWindowFunction(
-    type: WindowFunctionType,
-    fieldExpr: AnyColumn | SQL | null,
-    partitionBy?: (AnyColumn | SQL)[],
-    orderBy?: Array<{ field: AnyColumn | SQL; direction: 'asc' | 'desc' }>,
-    config?: WindowFunctionConfig
-  ): SQL {
-    // Build OVER clause components
-    const partitionClause = partitionBy && partitionBy.length > 0
-      ? sql`PARTITION BY ${sql.join(partitionBy, sql`, `)}`
-      : sql``
-
-    const orderClause = orderBy && orderBy.length > 0
-      ? sql`ORDER BY ${sql.join(orderBy.map(o =>
-          o.direction === 'desc' ? sql`${o.field} DESC` : sql`${o.field} ASC`
-        ), sql`, `)}`
-      : sql``
-
-    // Build frame clause if specified
-    let frameClause = sql``
-    if (config?.frame) {
-      const { type: frameType, start, end } = config.frame
-      const frameTypeStr = frameType.toUpperCase()
-
-      const startStr = start === 'unbounded' ? 'UNBOUNDED PRECEDING'
-        : typeof start === 'number' ? `${start} PRECEDING`
-        : 'CURRENT ROW'
-
-      const endStr = end === 'unbounded' ? 'UNBOUNDED FOLLOWING'
-        : end === 'current' ? 'CURRENT ROW'
-        : typeof end === 'number' ? `${end} FOLLOWING`
-        : 'CURRENT ROW'
-
-      frameClause = sql`${sql.raw(frameTypeStr)} BETWEEN ${sql.raw(startStr)} AND ${sql.raw(endStr)}`
-    }
-
-    // Combine OVER clause
-    const overParts: SQL[] = []
-    if (partitionBy && partitionBy.length > 0) overParts.push(partitionClause)
-    if (orderBy && orderBy.length > 0) overParts.push(orderClause)
-    if (config?.frame) overParts.push(frameClause)
-
-    const overContent = overParts.length > 0 ? sql.join(overParts, sql` `) : sql``
-    const over = sql`OVER (${overContent})`
-
-    // Build the window function based on type
-    switch (type) {
-      case 'lag':
-        return sql`LAG(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'lead':
-        return sql`LEAD(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'rank':
-        return sql`RANK() ${over}`
-      case 'denseRank':
-        return sql`DENSE_RANK() ${over}`
-      case 'rowNumber':
-        return sql`ROW_NUMBER() ${over}`
-      case 'ntile':
-        return sql`NTILE(${config?.nTile ?? 4}) ${over}`
-      case 'firstValue':
-        return sql`FIRST_VALUE(${fieldExpr}) ${over}`
-      case 'lastValue':
-        return sql`LAST_VALUE(${fieldExpr}) ${over}`
-      case 'movingAvg':
-        return sql`AVG(${fieldExpr}) ${over}`
-      case 'movingSum':
-        return sql`SUM(${fieldExpr}) ${over}`
-      default:
-        throw new Error(`Unsupported window function: ${type}`)
-    }
   }
 }

--- a/src/server/adapters/postgres-adapter.ts
+++ b/src/server/adapters/postgres-adapter.ts
@@ -2,11 +2,15 @@
  * PostgreSQL Database Adapter
  * Implements PostgreSQL-specific SQL generation for time dimensions, string matching, and type casting
  * Extracted from hardcoded logic in executor.ts and multi-cube-builder.ts
+ *
+ * Inherits shared defaults from BaseDatabaseAdapter (ILIKE string matching, ~* regex,
+ * COALESCE null-handling, standard window functions, etc.). Only PostgreSQL-specific
+ * SQL generation is implemented here.
  */
 
 import { sql, type SQL, type AnyColumn } from 'drizzle-orm'
 import type { TimeGranularity } from '../types'
-import { BaseDatabaseAdapter, type DatabaseCapabilities, type WindowFunctionType, type WindowFunctionConfig } from './base-adapter'
+import { BaseDatabaseAdapter, type DatabaseCapabilities } from './base-adapter'
 
 export class PostgresAdapter extends BaseDatabaseAdapter {
   getEngineType(): 'postgres' {
@@ -135,35 +139,6 @@ export class PostgresAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build PostgreSQL string matching conditions using ILIKE (case-insensitive)
-   * Extracted from executor.ts:807-813 and multi-cube-builder.ts:468-474
-   */
-  buildStringCondition(fieldExpr: AnyColumn | SQL, operator: 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'like' | 'notLike' | 'ilike' | 'regex' | 'notRegex', value: string): SQL {
-    switch (operator) {
-      case 'contains':
-        return sql`${fieldExpr} ILIKE ${`%${value}%`}`
-      case 'notContains':
-        return sql`${fieldExpr} NOT ILIKE ${`%${value}%`}`
-      case 'startsWith':
-        return sql`${fieldExpr} ILIKE ${`${value}%`}`
-      case 'endsWith':
-        return sql`${fieldExpr} ILIKE ${`%${value}`}`
-      case 'like':
-        return sql`${fieldExpr} LIKE ${value}`
-      case 'notLike':
-        return sql`${fieldExpr} NOT LIKE ${value}`
-      case 'ilike':
-        return sql`${fieldExpr} ILIKE ${value}`
-      case 'regex':
-        return sql`${fieldExpr} ~* ${value}`
-      case 'notRegex':
-        return sql`${fieldExpr} !~* ${value}`
-      default:
-        throw new Error(`Unsupported string operator: ${operator}`)
-    }
-  }
-
-  /**
    * Build PostgreSQL type casting using :: syntax
    * Extracted from various locations where ::timestamp was used
    */
@@ -178,68 +153,6 @@ export class PostgresAdapter extends BaseDatabaseAdapter {
       default:
         throw new Error(`Unsupported cast type: ${targetType}`)
     }
-  }
-
-
-  /**
-   * Build PostgreSQL AVG aggregation with COALESCE for NULL handling
-   * PostgreSQL AVG returns NULL for empty sets, so we use COALESCE for consistent behavior
-   * Extracted from multi-cube-builder.ts:284
-   */
-  buildAvg(fieldExpr: AnyColumn | SQL): SQL {
-    return sql`COALESCE(AVG(${fieldExpr}), 0)`
-  }
-
-
-  /**
-   * Build PostgreSQL CASE WHEN conditional expression
-   */
-  buildCaseWhen(conditions: Array<{ when: SQL; then: any }>, elseValue?: any): SQL {
-    const cases = conditions.map(c => sql`WHEN ${c.when} THEN ${c.then}`).reduce((acc, curr) => sql`${acc} ${curr}`)
-    
-    if (elseValue !== undefined) {
-      return sql`CASE ${cases} ELSE ${elseValue} END`
-    }
-    return sql`CASE ${cases} END`
-  }
-
-  /**
-   * Build PostgreSQL boolean literal
-   * PostgreSQL uses TRUE/FALSE keywords
-   */
-  buildBooleanLiteral(value: boolean): SQL {
-    return value ? sql`TRUE` : sql`FALSE`
-  }
-
-  /**
-   * Convert filter values - PostgreSQL uses native types
-   * No conversion needed for PostgreSQL
-   */
-  convertFilterValue(value: any): any {
-    return value
-  }
-
-  /**
-   * Prepare date value for PostgreSQL
-   * PostgreSQL accepts Date objects directly
-   */
-  prepareDateValue(date: Date): any {
-    return date
-  }
-
-  /**
-   * PostgreSQL stores timestamps as native timestamp types
-   */
-  isTimestampInteger(): boolean {
-    return false
-  }
-
-  /**
-   * PostgreSQL time dimensions already return proper values
-   * No conversion needed
-   */
-  convertTimeDimensionResult(value: any): any {
-    return value
   }
 
   // ============================================
@@ -264,105 +177,11 @@ export class PostgresAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build PostgreSQL STDDEV aggregation
-   * Uses STDDEV_POP for population, STDDEV_SAMP for sample
-   */
-  buildStddev(fieldExpr: AnyColumn | SQL, useSample = false): SQL {
-    const fn = useSample ? 'STDDEV_SAMP' : 'STDDEV_POP'
-    return sql`COALESCE(${sql.raw(fn)}(${fieldExpr}), 0)`
-  }
-
-  /**
-   * Build PostgreSQL VARIANCE aggregation
-   * Uses VAR_POP for population, VAR_SAMP for sample
-   */
-  buildVariance(fieldExpr: AnyColumn | SQL, useSample = false): SQL {
-    const fn = useSample ? 'VAR_SAMP' : 'VAR_POP'
-    return sql`COALESCE(${sql.raw(fn)}(${fieldExpr}), 0)`
-  }
-
-  /**
    * Build PostgreSQL PERCENTILE_CONT aggregation
    * Uses ordered-set aggregate function
    */
   buildPercentile(fieldExpr: AnyColumn | SQL, percentile: number): SQL {
     const pct = percentile / 100
     return sql`PERCENTILE_CONT(${pct}) WITHIN GROUP (ORDER BY ${fieldExpr})`
-  }
-
-  /**
-   * Build PostgreSQL window function expression
-   * PostgreSQL has full window function support
-   */
-  buildWindowFunction(
-    type: WindowFunctionType,
-    fieldExpr: AnyColumn | SQL | null,
-    partitionBy?: (AnyColumn | SQL)[],
-    orderBy?: Array<{ field: AnyColumn | SQL; direction: 'asc' | 'desc' }>,
-    config?: WindowFunctionConfig
-  ): SQL {
-    // Build OVER clause components
-    const partitionClause = partitionBy && partitionBy.length > 0
-      ? sql`PARTITION BY ${sql.join(partitionBy, sql`, `)}`
-      : sql``
-
-    const orderClause = orderBy && orderBy.length > 0
-      ? sql`ORDER BY ${sql.join(orderBy.map(o =>
-          o.direction === 'desc' ? sql`${o.field} DESC` : sql`${o.field} ASC`
-        ), sql`, `)}`
-      : sql``
-
-    // Build frame clause if specified
-    let frameClause = sql``
-    if (config?.frame) {
-      const { type: frameType, start, end } = config.frame
-      const frameTypeStr = frameType.toUpperCase()
-
-      const startStr = start === 'unbounded' ? 'UNBOUNDED PRECEDING'
-        : typeof start === 'number' ? `${start} PRECEDING`
-        : 'CURRENT ROW'
-
-      const endStr = end === 'unbounded' ? 'UNBOUNDED FOLLOWING'
-        : end === 'current' ? 'CURRENT ROW'
-        : typeof end === 'number' ? `${end} FOLLOWING`
-        : 'CURRENT ROW'
-
-      frameClause = sql`${sql.raw(frameTypeStr)} BETWEEN ${sql.raw(startStr)} AND ${sql.raw(endStr)}`
-    }
-
-    // Combine OVER clause
-    const overParts: SQL[] = []
-    if (partitionBy && partitionBy.length > 0) overParts.push(partitionClause)
-    if (orderBy && orderBy.length > 0) overParts.push(orderClause)
-    if (config?.frame) overParts.push(frameClause)
-
-    const overContent = overParts.length > 0 ? sql.join(overParts, sql` `) : sql``
-    const over = sql`OVER (${overContent})`
-
-    // Build the window function based on type
-    switch (type) {
-      case 'lag':
-        return sql`LAG(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'lead':
-        return sql`LEAD(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'rank':
-        return sql`RANK() ${over}`
-      case 'denseRank':
-        return sql`DENSE_RANK() ${over}`
-      case 'rowNumber':
-        return sql`ROW_NUMBER() ${over}`
-      case 'ntile':
-        return sql`NTILE(${config?.nTile ?? 4}) ${over}`
-      case 'firstValue':
-        return sql`FIRST_VALUE(${fieldExpr}) ${over}`
-      case 'lastValue':
-        return sql`LAST_VALUE(${fieldExpr}) ${over}`
-      case 'movingAvg':
-        return sql`AVG(${fieldExpr}) ${over}`
-      case 'movingSum':
-        return sql`SUM(${fieldExpr}) ${over}`
-      default:
-        throw new Error(`Unsupported window function: ${type}`)
-    }
   }
 }

--- a/src/server/adapters/snowflake-adapter.ts
+++ b/src/server/adapters/snowflake-adapter.ts
@@ -5,11 +5,14 @@
  * VAR_POP/VAR_SAMP, PERCENTILE_CONT, and window functions.
  * Key difference: uses DATEADD(unit, amount, ts) instead of INTERVAL arithmetic,
  * and TABLE(GENERATOR(ROWCOUNT => n)) instead of generate_series()
+ *
+ * Inherits shared defaults from BaseDatabaseAdapter (ILIKE matching, CASE WHEN conditional
+ * aggregation, COALESCE null-handling, standard window functions). Only Snowflake-specific SQL is here.
  */
 
 import { sql, type SQL, type AnyColumn } from 'drizzle-orm'
 import type { TimeGranularity } from '../types'
-import { BaseDatabaseAdapter, type DatabaseCapabilities, type WindowFunctionType, type WindowFunctionConfig } from './base-adapter'
+import { BaseDatabaseAdapter, type DatabaseCapabilities } from './base-adapter'
 
 export class SnowflakeAdapter extends BaseDatabaseAdapter {
   getEngineType(): 'snowflake' {
@@ -29,17 +32,11 @@ export class SnowflakeAdapter extends BaseDatabaseAdapter {
 
   /**
    * Build Snowflake INTERVAL from ISO 8601 duration
-   * Snowflake doesn't support INTERVAL literal syntax directly in all contexts,
-   * so we chain DATEADD calls. For standalone interval expressions, we return
-   * a DATEADD chain applied to TIMESTAMP '1970-01-01' and subtract it back.
-   * However, buildIntervalFromISO is typically used with buildDateAddInterval,
-   * so we return a structured representation.
+   * Snowflake doesn't have a standalone INTERVAL type like PostgreSQL.
+   * We convert to total seconds for use in DATEADD; callers should prefer buildDateAddInterval.
    */
   buildIntervalFromISO(duration: string): SQL {
-    // Snowflake doesn't have a standalone INTERVAL type like PostgreSQL.
-    // We convert to total seconds for use in DATEADD.
     const totalSeconds = this.durationToSeconds(duration)
-    // Return as a seconds value - callers should use buildDateAddInterval instead
     return sql`${totalSeconds}`
   }
 
@@ -67,22 +64,6 @@ export class SnowflakeAdapter extends BaseDatabaseAdapter {
     if (parsed.seconds) result = sql`DATEADD('SECOND', ${parsed.seconds}, ${result})`
 
     return result
-  }
-
-  /**
-   * Build Snowflake conditional aggregation using CASE WHEN
-   * Snowflake supports FILTER clause but CASE WHEN is more portable
-   */
-  buildConditionalAggregation(
-    aggFn: 'count' | 'avg' | 'min' | 'max' | 'sum',
-    expr: SQL | null,
-    condition: SQL
-  ): SQL {
-    const fnName = aggFn.toUpperCase()
-    if (aggFn === 'count' && !expr) {
-      return sql`${sql.raw(fnName)}(CASE WHEN ${condition} THEN 1 END)`
-    }
-    return sql`${sql.raw(fnName)}(CASE WHEN ${condition} THEN ${expr} END)`
   }
 
   /**
@@ -128,32 +109,12 @@ export class SnowflakeAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build Snowflake string matching conditions using native ILIKE
-   * Snowflake supports ILIKE natively
+   * Snowflake uses function-style regex matching: REGEXP_LIKE(field, pattern)
    */
-  buildStringCondition(fieldExpr: AnyColumn | SQL, operator: 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'like' | 'notLike' | 'ilike' | 'regex' | 'notRegex', value: string): SQL {
-    switch (operator) {
-      case 'contains':
-        return sql`${fieldExpr} ILIKE ${`%${value}%`}`
-      case 'notContains':
-        return sql`${fieldExpr} NOT ILIKE ${`%${value}%`}`
-      case 'startsWith':
-        return sql`${fieldExpr} ILIKE ${`${value}%`}`
-      case 'endsWith':
-        return sql`${fieldExpr} ILIKE ${`%${value}`}`
-      case 'like':
-        return sql`${fieldExpr} LIKE ${value}`
-      case 'notLike':
-        return sql`${fieldExpr} NOT LIKE ${value}`
-      case 'ilike':
-        return sql`${fieldExpr} ILIKE ${value}`
-      case 'regex':
-        return sql`REGEXP_LIKE(${fieldExpr}, ${value})`
-      case 'notRegex':
-        return sql`NOT REGEXP_LIKE(${fieldExpr}, ${value})`
-      default:
-        throw new Error(`Unsupported string operator: ${operator}`)
-    }
+  protected regexCondition(fieldExpr: AnyColumn | SQL, value: string, negated: boolean): SQL {
+    return negated
+      ? sql`NOT REGEXP_LIKE(${fieldExpr}, ${value})`
+      : sql`REGEXP_LIKE(${fieldExpr}, ${value})`
   }
 
   /**
@@ -171,62 +132,6 @@ export class SnowflakeAdapter extends BaseDatabaseAdapter {
       default:
         throw new Error(`Unsupported cast type: ${targetType}`)
     }
-  }
-
-  /**
-   * Build Snowflake AVG aggregation with COALESCE for NULL handling
-   */
-  buildAvg(fieldExpr: AnyColumn | SQL): SQL {
-    return sql`COALESCE(AVG(${fieldExpr}), 0)`
-  }
-
-  /**
-   * Build Snowflake CASE WHEN conditional expression
-   */
-  buildCaseWhen(conditions: Array<{ when: SQL; then: any }>, elseValue?: any): SQL {
-    const cases = conditions.map(c => sql`WHEN ${c.when} THEN ${c.then}`).reduce((acc, curr) => sql`${acc} ${curr}`)
-
-    if (elseValue !== undefined) {
-      return sql`CASE ${cases} ELSE ${elseValue} END`
-    }
-    return sql`CASE ${cases} END`
-  }
-
-  /**
-   * Build Snowflake boolean literal
-   * Snowflake uses TRUE/FALSE keywords
-   */
-  buildBooleanLiteral(value: boolean): SQL {
-    return value ? sql`TRUE` : sql`FALSE`
-  }
-
-  /**
-   * Convert filter values - Snowflake uses native types
-   */
-  convertFilterValue(value: any): any {
-    return value
-  }
-
-  /**
-   * Prepare date value for Snowflake
-   * Snowflake accepts Date objects directly
-   */
-  prepareDateValue(date: Date): any {
-    return date
-  }
-
-  /**
-   * Snowflake stores timestamps as native timestamp types
-   */
-  isTimestampInteger(): boolean {
-    return false
-  }
-
-  /**
-   * Snowflake time dimensions already return proper values
-   */
-  convertTimeDimensionResult(value: any): any {
-    return value
   }
 
   // ============================================
@@ -251,23 +156,6 @@ export class SnowflakeAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build Snowflake STDDEV aggregation
-   */
-  buildStddev(fieldExpr: AnyColumn | SQL, useSample = false): SQL {
-    const fn = useSample ? 'STDDEV_SAMP' : 'STDDEV_POP'
-    return sql`COALESCE(${sql.raw(fn)}(${fieldExpr}), 0)`
-  }
-
-  /**
-   * Build Snowflake VARIANCE aggregation
-   * Snowflake supports native VAR_POP/VAR_SAMP
-   */
-  buildVariance(fieldExpr: AnyColumn | SQL, useSample = false): SQL {
-    const fn = useSample ? 'VAR_SAMP' : 'VAR_POP'
-    return sql`COALESCE(${sql.raw(fn)}(${fieldExpr}), 0)`
-  }
-
-  /**
    * Build Snowflake PERCENTILE_CONT aggregation
    * Uses ordered-set aggregate function
    */
@@ -275,81 +163,5 @@ export class SnowflakeAdapter extends BaseDatabaseAdapter {
     // Snowflake requires PERCENTILE_CONT argument to be a constant literal, not a bind variable
     const pct = (percentile / 100).toString()
     return sql`PERCENTILE_CONT(${sql.raw(pct)}) WITHIN GROUP (ORDER BY ${fieldExpr})`
-  }
-
-  /**
-   * Build Snowflake window function expression
-   * Snowflake has full window function support
-   */
-  buildWindowFunction(
-    type: WindowFunctionType,
-    fieldExpr: AnyColumn | SQL | null,
-    partitionBy?: (AnyColumn | SQL)[],
-    orderBy?: Array<{ field: AnyColumn | SQL; direction: 'asc' | 'desc' }>,
-    config?: WindowFunctionConfig
-  ): SQL {
-    // Build OVER clause components
-    const partitionClause = partitionBy && partitionBy.length > 0
-      ? sql`PARTITION BY ${sql.join(partitionBy, sql`, `)}`
-      : sql``
-
-    const orderClause = orderBy && orderBy.length > 0
-      ? sql`ORDER BY ${sql.join(orderBy.map(o =>
-          o.direction === 'desc' ? sql`${o.field} DESC` : sql`${o.field} ASC`
-        ), sql`, `)}`
-      : sql``
-
-    // Build frame clause if specified
-    let frameClause = sql``
-    if (config?.frame) {
-      const { type: frameType, start, end } = config.frame
-      const frameTypeStr = frameType.toUpperCase()
-
-      const startStr = start === 'unbounded' ? 'UNBOUNDED PRECEDING'
-        : typeof start === 'number' ? `${start} PRECEDING`
-        : 'CURRENT ROW'
-
-      const endStr = end === 'unbounded' ? 'UNBOUNDED FOLLOWING'
-        : end === 'current' ? 'CURRENT ROW'
-        : typeof end === 'number' ? `${end} FOLLOWING`
-        : 'CURRENT ROW'
-
-      frameClause = sql`${sql.raw(frameTypeStr)} BETWEEN ${sql.raw(startStr)} AND ${sql.raw(endStr)}`
-    }
-
-    // Combine OVER clause
-    const overParts: SQL[] = []
-    if (partitionBy && partitionBy.length > 0) overParts.push(partitionClause)
-    if (orderBy && orderBy.length > 0) overParts.push(orderClause)
-    if (config?.frame) overParts.push(frameClause)
-
-    const overContent = overParts.length > 0 ? sql.join(overParts, sql` `) : sql``
-    const over = sql`OVER (${overContent})`
-
-    // Build the window function based on type
-    switch (type) {
-      case 'lag':
-        return sql`LAG(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'lead':
-        return sql`LEAD(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'rank':
-        return sql`RANK() ${over}`
-      case 'denseRank':
-        return sql`DENSE_RANK() ${over}`
-      case 'rowNumber':
-        return sql`ROW_NUMBER() ${over}`
-      case 'ntile':
-        return sql`NTILE(${config?.nTile ?? 4}) ${over}`
-      case 'firstValue':
-        return sql`FIRST_VALUE(${fieldExpr}) ${over}`
-      case 'lastValue':
-        return sql`LAST_VALUE(${fieldExpr}) ${over}`
-      case 'movingAvg':
-        return sql`AVG(${fieldExpr}) ${over}`
-      case 'movingSum':
-        return sql`SUM(${fieldExpr}) ${over}`
-      default:
-        throw new Error(`Unsupported window function: ${type}`)
-    }
   }
 }

--- a/src/server/adapters/sqlite-adapter.ts
+++ b/src/server/adapters/sqlite-adapter.ts
@@ -2,11 +2,15 @@
  * SQLite Database Adapter
  * Implements SQLite-specific SQL generation for time dimensions, string matching, and type casting
  * Supports local SQLite with better-sqlite3 driver
+ *
+ * SQLite is the biggest outlier: timestamps are stored as integer milliseconds, there is no
+ * native ILIKE/STDDEV/VARIANCE, booleans are 1/0, and CASE WHEN must handle embedded SQL objects.
+ * It therefore overrides more of BaseDatabaseAdapter's shared defaults than any other engine.
  */
 
 import { sql, type SQL, type AnyColumn } from 'drizzle-orm'
 import type { TimeGranularity } from '../types'
-import { BaseDatabaseAdapter, type DatabaseCapabilities, type WindowFunctionType, type WindowFunctionConfig } from './base-adapter'
+import { BaseDatabaseAdapter, type DatabaseCapabilities } from './base-adapter'
 
 export class SQLiteAdapter extends BaseDatabaseAdapter {
   getEngineType(): 'sqlite' {
@@ -51,25 +55,6 @@ export class SQLiteAdapter extends BaseDatabaseAdapter {
   buildDateAddInterval(timestamp: SQL, duration: string): SQL {
     const totalSeconds = this.durationToSeconds(duration)
     return sql`(${timestamp} + ${totalSeconds})`
-  }
-
-  /**
-   * Build SQLite conditional aggregation using CASE WHEN
-   * SQLite doesn't support FILTER clause, so we use CASE WHEN pattern
-   * Example: AVG(CASE WHEN step_1_time IS NOT NULL THEN time_diff END)
-   */
-  buildConditionalAggregation(
-    aggFn: 'count' | 'avg' | 'min' | 'max' | 'sum',
-    expr: SQL | null,
-    condition: SQL
-  ): SQL {
-    const fnName = aggFn.toUpperCase()
-    if (aggFn === 'count' && !expr) {
-      // COUNT(*) with condition -> COUNT(CASE WHEN condition THEN 1 END)
-      return sql`COUNT(CASE WHEN ${condition} THEN 1 END)`
-    }
-    // AVG/MIN/MAX/SUM -> AGG(CASE WHEN condition THEN expr END)
-    return sql`${sql.raw(fnName)}(CASE WHEN ${condition} THEN ${expr} END)`
   }
 
   /**
@@ -163,35 +148,22 @@ export class SQLiteAdapter extends BaseDatabaseAdapter {
   }
 
   /**
-   * Build SQLite string matching conditions using LOWER() + LIKE for case-insensitive matching
-   * SQLite LIKE is case-insensitive by default, but LOWER() ensures consistency
+   * SQLite has no ILIKE — use LOWER()+LIKE with the pattern lowercased in JS.
    */
-  buildStringCondition(fieldExpr: AnyColumn | SQL, operator: 'contains' | 'notContains' | 'startsWith' | 'endsWith' | 'like' | 'notLike' | 'ilike' | 'regex' | 'notRegex', value: string): SQL {
-    switch (operator) {
-      case 'contains':
-        return sql`LOWER(${fieldExpr}) LIKE ${`%${value.toLowerCase()}%`}`
-      case 'notContains':
-        return sql`LOWER(${fieldExpr}) NOT LIKE ${`%${value.toLowerCase()}%`}`
-      case 'startsWith':
-        return sql`LOWER(${fieldExpr}) LIKE ${`${value.toLowerCase()}%`}`
-      case 'endsWith':
-        return sql`LOWER(${fieldExpr}) LIKE ${`%${value.toLowerCase()}`}`
-      case 'like':
-        return sql`${fieldExpr} LIKE ${value}`
-      case 'notLike':
-        return sql`${fieldExpr} NOT LIKE ${value}`
-      case 'ilike':
-        // SQLite doesn't have ILIKE, use LOWER() + LIKE for case-insensitive
-        return sql`LOWER(${fieldExpr}) LIKE ${value.toLowerCase()}`
-      case 'regex':
-        // SQLite regex requires loading extension, use GLOB as fallback
-        return sql`${fieldExpr} GLOB ${value}`
-      case 'notRegex':
-        // SQLite regex requires loading extension, use NOT GLOB as fallback
-        return sql`${fieldExpr} NOT GLOB ${value}`
-      default:
-        throw new Error(`Unsupported string operator: ${operator}`)
-    }
+  protected caseInsensitiveLike(fieldExpr: AnyColumn | SQL, pattern: string, negated: boolean): SQL {
+    const lowered = pattern.toLowerCase()
+    return negated
+      ? sql`LOWER(${fieldExpr}) NOT LIKE ${lowered}`
+      : sql`LOWER(${fieldExpr}) LIKE ${lowered}`
+  }
+
+  /**
+   * SQLite regex requires loading an extension, so GLOB is used as a fallback.
+   */
+  protected regexCondition(fieldExpr: AnyColumn | SQL, value: string, negated: boolean): SQL {
+    return negated
+      ? sql`${fieldExpr} NOT GLOB ${value}`
+      : sql`${fieldExpr} GLOB ${value}`
   }
 
   /**
@@ -214,27 +186,26 @@ export class SQLiteAdapter extends BaseDatabaseAdapter {
     }
   }
 
-
   /**
-   * Build SQLite AVG aggregation with IFNULL for NULL handling
-   * SQLite AVG returns NULL for empty sets, using IFNULL for consistency
+   * SQLite AVG uses IFNULL rather than COALESCE for null-to-zero handling.
    */
-  buildAvg(fieldExpr: AnyColumn | SQL): SQL {
-    return sql`IFNULL(AVG(${fieldExpr}), 0)`
+  protected nullToZero(expr: SQL): SQL {
+    return sql`IFNULL(${expr}, 0)`
   }
 
-
   /**
-   * Build SQLite CASE WHEN conditional expression
+   * Build SQLite CASE WHEN conditional expression.
+   * Unlike the base implementation, SQLite must detect embedded SQL objects in THEN/ELSE
+   * and inline them rather than binding them as parameters.
    */
   buildCaseWhen(conditions: Array<{ when: SQL; then: any }>, elseValue?: any): SQL {
     // Check if 'then' values are SQL objects (they have queryChunks property)
     // If so, we need to treat them as SQL expressions, not bound parameters
     const cases = conditions.map(c => {
       // Check if it's a SQL object by checking for SQL-like properties
-      const isSqlObject = c.then && typeof c.then === 'object' && 
+      const isSqlObject = c.then && typeof c.then === 'object' &&
                          (c.then.queryChunks || c.then._ || c.then.sql);
-      
+
       if (isSqlObject) {
         // It's a SQL expression, embed it directly without parameterization
         return sql`WHEN ${c.when} THEN ${sql.raw('(') }${c.then}${sql.raw(')')}`
@@ -243,9 +214,9 @@ export class SQLiteAdapter extends BaseDatabaseAdapter {
         return sql`WHEN ${c.when} THEN ${c.then}`
       }
     }).reduce((acc, curr) => sql`${acc} ${curr}`)
-    
+
     if (elseValue !== undefined) {
-      const isElseSqlObject = elseValue && typeof elseValue === 'object' && 
+      const isElseSqlObject = elseValue && typeof elseValue === 'object' &&
                               (elseValue.queryChunks || elseValue._ || elseValue.sql);
       if (isElseSqlObject) {
         return sql`CASE ${cases} ELSE ${sql.raw('(')}${elseValue}${sql.raw(')')} END`
@@ -291,7 +262,6 @@ export class SQLiteAdapter extends BaseDatabaseAdapter {
     })
   }
 
-
   /**
    * Convert filter values to SQLite-compatible types
    * SQLite doesn't support boolean types - convert boolean to integer (1/0)
@@ -310,7 +280,7 @@ export class SQLiteAdapter extends BaseDatabaseAdapter {
     // If it's already a number (likely already converted timestamp), return as-is
     if (typeof value === 'number') {
       return value
-    }    
+    }
     return value
   }
 
@@ -334,14 +304,6 @@ export class SQLiteAdapter extends BaseDatabaseAdapter {
    */
   isTimestampInteger(): boolean {
     return true
-  }
-
-  /**
-   * Convert SQLite time dimension results back to Date objects
-   * SQLite time dimensions return datetime strings, but clients expect Date objects
-   */
-  convertTimeDimensionResult(value: any): any {
-    return value
   }
 
   // ============================================
@@ -394,81 +356,5 @@ export class SQLiteAdapter extends BaseDatabaseAdapter {
     // SQLite doesn't have native PERCENTILE functions
     // Return null to trigger graceful degradation
     return null
-  }
-
-  /**
-   * Build SQLite window function expression
-   * SQLite 3.25+ supports window functions
-   */
-  buildWindowFunction(
-    type: WindowFunctionType,
-    fieldExpr: AnyColumn | SQL | null,
-    partitionBy?: (AnyColumn | SQL)[],
-    orderBy?: Array<{ field: AnyColumn | SQL; direction: 'asc' | 'desc' }>,
-    config?: WindowFunctionConfig
-  ): SQL {
-    // Build OVER clause components
-    const partitionClause = partitionBy && partitionBy.length > 0
-      ? sql`PARTITION BY ${sql.join(partitionBy, sql`, `)}`
-      : sql``
-
-    const orderClause = orderBy && orderBy.length > 0
-      ? sql`ORDER BY ${sql.join(orderBy.map(o =>
-          o.direction === 'desc' ? sql`${o.field} DESC` : sql`${o.field} ASC`
-        ), sql`, `)}`
-      : sql``
-
-    // Build frame clause if specified
-    let frameClause = sql``
-    if (config?.frame) {
-      const { type: frameType, start, end } = config.frame
-      const frameTypeStr = frameType.toUpperCase()
-
-      const startStr = start === 'unbounded' ? 'UNBOUNDED PRECEDING'
-        : typeof start === 'number' ? `${start} PRECEDING`
-        : 'CURRENT ROW'
-
-      const endStr = end === 'unbounded' ? 'UNBOUNDED FOLLOWING'
-        : end === 'current' ? 'CURRENT ROW'
-        : typeof end === 'number' ? `${end} FOLLOWING`
-        : 'CURRENT ROW'
-
-      frameClause = sql`${sql.raw(frameTypeStr)} BETWEEN ${sql.raw(startStr)} AND ${sql.raw(endStr)}`
-    }
-
-    // Combine OVER clause
-    const overParts: SQL[] = []
-    if (partitionBy && partitionBy.length > 0) overParts.push(partitionClause)
-    if (orderBy && orderBy.length > 0) overParts.push(orderClause)
-    if (config?.frame) overParts.push(frameClause)
-
-    const overContent = overParts.length > 0 ? sql.join(overParts, sql` `) : sql``
-    const over = sql`OVER (${overContent})`
-
-    // Build the window function based on type
-    switch (type) {
-      case 'lag':
-        return sql`LAG(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'lead':
-        return sql`LEAD(${fieldExpr}, ${config?.offset ?? 1}${config?.defaultValue !== undefined ? sql`, ${config.defaultValue}` : sql``}) ${over}`
-      case 'rank':
-        return sql`RANK() ${over}`
-      case 'denseRank':
-        return sql`DENSE_RANK() ${over}`
-      case 'rowNumber':
-        return sql`ROW_NUMBER() ${over}`
-      case 'ntile':
-        return sql`NTILE(${config?.nTile ?? 4}) ${over}`
-      case 'firstValue':
-        return sql`FIRST_VALUE(${fieldExpr}) ${over}`
-      case 'lastValue':
-        return sql`LAST_VALUE(${fieldExpr}) ${over}`
-      case 'movingAvg':
-        return sql`AVG(${fieldExpr}) ${over}`
-      case 'movingSum':
-        return sql`SUM(${fieldExpr}) ${over}`
-      default:
-        throw new Error(`Unsupported window function: ${type}`)
-    }
   }
 }

--- a/src/server/ai/discovery.ts
+++ b/src/server/ai/discovery.ts
@@ -66,7 +66,7 @@ export interface DiscoveryOptions {
 /**
  * Calculate Levenshtein distance between two strings
  */
-function levenshteinDistance(a: string, b: string): number {
+export function levenshteinDistance(a: string, b: string): number {
   if (a.length > 500 || b.length > 500) return a.length + b.length
   const matrix: number[][] = []
 

--- a/src/server/ai/validation.ts
+++ b/src/server/ai/validation.ts
@@ -6,7 +6,7 @@
 import { t } from '../../i18n/runtime'
 import type { CubeMetadata } from '../types/metadata'
 import type { SemanticQuery, Filter } from '../types/query'
-import { findBestFieldMatch } from './discovery'
+import { findBestFieldMatch, levenshteinDistance } from './discovery'
 
 /**
  * Validation result with corrections
@@ -37,38 +37,6 @@ export interface ValidationWarning {
   message: string
   field?: string
   suggestion?: string
-}
-
-/**
- * Levenshtein distance for fuzzy matching (copied from discovery for standalone use)
- */
-function levenshteinDistance(a: string, b: string): number {
-  if (a.length > 500 || b.length > 500) return a.length + b.length
-  const matrix: number[][] = []
-
-  for (let i = 0; i <= b.length; i++) {
-    matrix[i] = [i]
-  }
-
-  for (let j = 0; j <= a.length; j++) {
-    matrix[0][j] = j
-  }
-
-  for (let i = 1; i <= b.length; i++) {
-    for (let j = 1; j <= a.length; j++) {
-      if (b.charAt(i - 1) === a.charAt(j - 1)) {
-        matrix[i][j] = matrix[i - 1][j - 1]
-      } else {
-        matrix[i][j] = Math.min(
-          matrix[i - 1][j - 1] + 1,
-          matrix[i][j - 1] + 1,
-          matrix[i - 1][j] + 1
-        )
-      }
-    }
-  }
-
-  return matrix[b.length][a.length]
 }
 
 /**

--- a/src/server/builders/analysis-utils.ts
+++ b/src/server/builders/analysis-utils.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared helpers for the analysis query builders (funnel / flow / retention).
+ *
+ * These builders bypass the logical plan and assemble SQL directly, so they
+ * historically duplicated a handful of small primitives. This module centralises
+ * the duplication while keeping the generated SQL byte-identical.
+ */
+
+import { and, SQL } from 'drizzle-orm'
+import { t } from '../../i18n/runtime'
+import type { Cube, QueryContext } from '../types'
+import { resolveSqlExpression } from '../cube-utils'
+
+/**
+ * Type for CTE objects created by db.$with()
+ * These can be used with db.with(...ctes).select().from(cte)
+ */
+export type WithSubquery = ReturnType<ReturnType<any['$with']>['as']>
+
+/**
+ * Combine an array of WHERE/JOIN conditions into a single SQL expression.
+ *
+ * - `[]`            → undefined (no condition)
+ * - single element  → that element verbatim
+ * - multiple        → `and(...conditions)`
+ *
+ * Mirrors the inline `conditions.length === 1 ? conditions[0] : and(...conditions) as SQL`
+ * pattern that was duplicated across the analysis builders.
+ */
+export function combineWhere(conditions: SQL[]): SQL | undefined {
+  if (conditions.length === 0) return undefined
+  if (conditions.length === 1) return conditions[0]
+  return and(...conditions) as SQL
+}
+
+/**
+ * A single multi-cube field mapping (binding key or time dimension), e.g.
+ * `{ cube: 'Events', dimension: 'Events.userId' }`.
+ */
+type FieldMapping = { cube: string; dimension: string }
+
+/**
+ * The i18n namespaces whose binding-key / time-dimension leaf keys are identical.
+ * Funnel and flow share the exact same leaf keys under these two prefixes, which
+ * is what lets the resolution logic below be shared. (Retention uses a different
+ * leaf-key set and is intentionally not routed through here — see its builder.)
+ */
+type AnalysisErrorPrefix = 'server.errors.funnel' | 'server.errors.flow'
+
+/**
+ * Resolve a binding-key SQL expression for funnel/flow builders.
+ *
+ * Accepts a `'Cube.dim'` string or an array of `{ cube, dimension }` mappings.
+ * `errorPrefix` selects the i18n namespace (the leaf keys are identical across
+ * funnel and flow): `<prefix>.bindingKeyDimNotFound`, `<prefix>.noBindingKeyMapping`,
+ * `<prefix>.bindingKeyMappingDimNotFound`.
+ */
+export function resolveBindingKeyExpr(
+  bindingKey: string | FieldMapping[],
+  cube: Cube,
+  context: QueryContext,
+  errorPrefix: AnalysisErrorPrefix
+): SQL {
+  if (typeof bindingKey === 'string') {
+    const [, dimName] = bindingKey.split('.')
+    const dimension = cube.dimensions?.[dimName]
+    if (!dimension) {
+      throw new Error(t(`${errorPrefix}.bindingKeyDimNotFound`, { bindingKey }))
+    }
+    return resolveSqlExpression(dimension.sql, context) as SQL
+  }
+
+  // Multi-cube binding key - find the mapping for this cube
+  const mapping = bindingKey.find(m => m.cube === cube.name)
+  if (!mapping) {
+    throw new Error(t(`${errorPrefix}.noBindingKeyMapping`, { cubeName: cube.name }))
+  }
+  const [, dimName] = mapping.dimension.split('.')
+  const dimension = cube.dimensions?.[dimName]
+  if (!dimension) {
+    throw new Error(t(`${errorPrefix}.bindingKeyMappingDimNotFound`, { dimension: mapping.dimension }))
+  }
+  return resolveSqlExpression(dimension.sql, context) as SQL
+}
+
+/**
+ * Resolve a time-dimension SQL expression for funnel/flow builders.
+ *
+ * Accepts a `'Cube.dim'` string or an array of `{ cube, dimension }` mappings.
+ * `errorPrefix` selects the i18n namespace (the leaf keys are identical across
+ * funnel and flow): `<prefix>.timeDimNotFound`, `<prefix>.noTimeDimMapping`,
+ * `<prefix>.timeDimMappingNotFound`.
+ */
+export function resolveTimeDimensionExpr(
+  timeDimension: string | FieldMapping[],
+  cube: Cube,
+  context: QueryContext,
+  errorPrefix: AnalysisErrorPrefix
+): SQL {
+  if (typeof timeDimension === 'string') {
+    const [, dimName] = timeDimension.split('.')
+    const dimension = cube.dimensions?.[dimName]
+    if (!dimension) {
+      throw new Error(t(`${errorPrefix}.timeDimNotFound`, { timeDimension }))
+    }
+    return resolveSqlExpression(dimension.sql, context) as SQL
+  }
+
+  // Multi-cube time dimension - find the mapping for this cube
+  const mapping = timeDimension.find(m => m.cube === cube.name)
+  if (!mapping) {
+    throw new Error(t(`${errorPrefix}.noTimeDimMapping`, { cubeName: cube.name }))
+  }
+  const [, dimName] = mapping.dimension.split('.')
+  const dimension = cube.dimensions?.[dimName]
+  if (!dimension) {
+    throw new Error(t(`${errorPrefix}.timeDimMappingNotFound`, { dimension: mapping.dimension }))
+  }
+  return resolveSqlExpression(dimension.sql, context) as SQL
+}

--- a/src/server/builders/comparison-query-builder.ts
+++ b/src/server/builders/comparison-query-builder.ts
@@ -17,6 +17,7 @@ import type {
   PeriodComparisonMetadata
 } from '../types'
 import { DateTimeBuilder } from './date-time-builder'
+import { hasComparisonMode } from '../query-modes'
 import type { DatabaseAdapter } from '../adapters/base-adapter'
 
 /**
@@ -56,9 +57,7 @@ export class ComparisonQueryBuilder {
    * Check if a query contains compareDateRange
    */
   hasComparison(query: SemanticQuery): boolean {
-    return query.timeDimensions?.some(td =>
-      td.compareDateRange && td.compareDateRange.length >= 2
-    ) ?? false
+    return hasComparisonMode(query)
   }
 
   /**

--- a/src/server/builders/filter-builder.ts
+++ b/src/server/builders/filter-builder.ts
@@ -34,7 +34,7 @@ import type {
   QueryContext
 } from '../types'
 
-import { resolveSqlExpression } from '../cube-utils'
+import { resolveFilterFieldExpr } from '../cube-utils'
 import type { DatabaseAdapter } from '../adapters/base-adapter'
 import { DateTimeBuilder } from './date-time-builder'
 
@@ -313,12 +313,7 @@ export class FilterBuilder {
     const dimension = cube.dimensions?.[fieldName]
     if (!dimension) return null
 
-    // For non-time dimensions, use raw column so Drizzle preserves column type
-    // metadata for proper parameter binding (e.g., UUID columns need type info).
-    // For time dimensions, keep isolated SQL because normalizeDate() returns strings.
-    const fieldExpr = dimension.type === 'time'
-      ? resolveSqlExpression(dimension.sql, context)
-      : (typeof dimension.sql === 'function' ? dimension.sql(context) : dimension.sql)
+    const fieldExpr = resolveFilterFieldExpr(dimension, context)
     return this.buildFilterCondition(
       fieldExpr,
       fc.operator,

--- a/src/server/builders/flow-query-builder.ts
+++ b/src/server/builders/flow-query-builder.ts
@@ -21,8 +21,8 @@ import type {
   FlowResultRow,
   SankeyNode,
   SankeyLink,
-  FlowValidationResult,
 } from '../types/flow'
+import type { AnalysisConfigValidationResult } from '../types/validation'
 import type {
   Cube,
   QueryContext,
@@ -77,7 +77,7 @@ export class FlowQueryBuilder {
   validateConfig(
     config: FlowQueryConfig,
     cubes: Map<string, Cube>
-  ): FlowValidationResult {
+  ): AnalysisConfigValidationResult {
     const errors: string[] = []
     const warnings: string[] = []
     const engine = this.databaseAdapter.getEngineType()

--- a/src/server/builders/flow-query-builder.ts
+++ b/src/server/builders/flow-query-builder.ts
@@ -33,13 +33,9 @@ import type {
 } from '../types'
 import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
 import { hasFlowMode } from '../query-modes'
+import { combineWhere, resolveBindingKeyExpr, resolveTimeDimensionExpr, type WithSubquery } from './analysis-utils'
 import { FilterBuilder } from './filter-builder'
 import { DateTimeBuilder } from './date-time-builder'
-
-/**
- * Type for CTE objects created by db.$with()
- */
-type WithSubquery = ReturnType<ReturnType<any['$with']>['as']>
 
 /**
  * Resolved flow configuration with SQL expressions
@@ -240,14 +236,14 @@ export class FlowQueryBuilder {
 
     // 2. Before step CTEs - walk backwards from starting step
     const beforeCTEs = useLateral
-      ? this.buildBeforeCTEsLateral(effectiveConfig, resolved, context)
-      : this.buildBeforeCTEsWindow(effectiveConfig, resolved, context)
+      ? this.buildDirectionalCTEsLateral('before', effectiveConfig, resolved, context)
+      : this.buildDirectionalCTEsWindow('before', effectiveConfig, resolved, context)
     ctes.push(...beforeCTEs)
 
     // 3. After step CTEs - walk forwards from starting step
     const afterCTEs = useLateral
-      ? this.buildAfterCTEsLateral(effectiveConfig, resolved, context)
-      : this.buildAfterCTEsWindow(effectiveConfig, resolved, context)
+      ? this.buildDirectionalCTEsLateral('after', effectiveConfig, resolved, context)
+      : this.buildDirectionalCTEsWindow('after', effectiveConfig, resolved, context)
     ctes.push(...afterCTEs)
 
     // 4. Nodes aggregation CTE - count entities per (layer, event_type)
@@ -357,25 +353,7 @@ export class FlowQueryBuilder {
     cube: Cube,
     context: QueryContext
   ): SQL {
-    if (typeof config.bindingKey === 'string') {
-      const [, dimName] = config.bindingKey.split('.')
-      const dimension = cube.dimensions?.[dimName]
-      if (!dimension) {
-        throw new Error(t('server.errors.flow.bindingKeyDimNotFound', { bindingKey: config.bindingKey }))
-      }
-      return resolveSqlExpression(dimension.sql, context) as SQL
-    }
-
-    const mapping = config.bindingKey.find((m) => m.cube === cube.name)
-    if (!mapping) {
-      throw new Error(t('server.errors.flow.noBindingKeyMapping', { cubeName: cube.name }))
-    }
-    const [, dimName] = mapping.dimension.split('.')
-    const dimension = cube.dimensions?.[dimName]
-    if (!dimension) {
-      throw new Error(t('server.errors.flow.bindingKeyMappingDimNotFound', { dimension: mapping.dimension }))
-    }
-    return resolveSqlExpression(dimension.sql, context) as SQL
+    return resolveBindingKeyExpr(config.bindingKey, cube, context, 'server.errors.flow')
   }
 
   /**
@@ -386,25 +364,7 @@ export class FlowQueryBuilder {
     cube: Cube,
     context: QueryContext
   ): SQL {
-    if (typeof config.timeDimension === 'string') {
-      const [, dimName] = config.timeDimension.split('.')
-      const dimension = cube.dimensions?.[dimName]
-      if (!dimension) {
-        throw new Error(t('server.errors.flow.timeDimNotFound', { timeDimension: config.timeDimension }))
-      }
-      return resolveSqlExpression(dimension.sql, context) as SQL
-    }
-
-    const mapping = config.timeDimension.find((m) => m.cube === cube.name)
-    if (!mapping) {
-      throw new Error(t('server.errors.flow.noTimeDimMapping', { cubeName: cube.name }))
-    }
-    const [, dimName] = mapping.dimension.split('.')
-    const dimension = cube.dimensions?.[dimName]
-    if (!dimension) {
-      throw new Error(t('server.errors.flow.timeDimMappingNotFound', { dimension: mapping.dimension }))
-    }
-    return resolveSqlExpression(dimension.sql, context) as SQL
+    return resolveTimeDimensionExpr(config.timeDimension, cube, context, 'server.errors.flow')
   }
 
   /**
@@ -559,11 +519,7 @@ export class FlowQueryBuilder {
 
     // Apply WHERE conditions
     if (whereConditions.length > 0) {
-      const combinedWhere =
-        whereConditions.length === 1
-          ? whereConditions[0]
-          : (and(...whereConditions) as SQL)
-      query = query.where(combinedWhere)
+      query = query.where(combineWhere(whereConditions))
     }
 
     // Group by binding key and event type
@@ -578,10 +534,15 @@ export class FlowQueryBuilder {
   }
 
   /**
-   * Build CTEs for steps BEFORE the starting point using LATERAL joins
-   * Uses ORDER BY ... DESC LIMIT 1 to fetch immediate predecessor via index
+   * Build CTEs for steps BEFORE/AFTER the starting point using LATERAL joins
+   *
+   * Direction-parameterised: 'before' walks backwards (time `<` reference,
+   * ORDER BY DESC, `before_step_N` aliases, bounded by `stepsBefore`); 'after'
+   * walks forwards (time `>`, ORDER BY ASC, `after_step_N`, `stepsAfter`).
+   * Uses ORDER BY ... LIMIT 1 to fetch the immediate predecessor/successor via index.
    */
-  private buildBeforeCTEsLateral(
+  private buildDirectionalCTEsLateral(
+    direction: 'before' | 'after',
     config: FlowQueryConfig,
     resolved: ResolvedFlowConfig,
     context: QueryContext
@@ -590,10 +551,15 @@ export class FlowQueryBuilder {
     const ctes: WithSubquery[] = []
     const isSunburst = config.outputMode === 'sunburst'
 
-    for (let depth = 1; depth <= config.stepsBefore; depth++) {
-      const prevAlias = depth === 1 ? 'starting_entities' : `before_step_${depth - 1}`
+    const isBefore = direction === 'before'
+    const stepBound = isBefore ? config.stepsBefore : config.stepsAfter
+    const timeOp = isBefore ? sql`<` : sql`>`
+    const orderDir = isBefore ? sql`DESC` : sql`ASC`
+
+    for (let depth = 1; depth <= stepBound; depth++) {
+      const prevAlias = depth === 1 ? 'starting_entities' : `${direction}_step_${depth - 1}`
       const prevTimeColumn = depth === 1 ? 'start_time' : 'step_time'
-      const alias = `before_step_${depth}`
+      const alias = `${direction}_step_${depth}`
 
       const whereConditions: SQL[] = []
       if (cubeBase.where) {
@@ -601,15 +567,14 @@ export class FlowQueryBuilder {
       }
       whereConditions.push(
         sql`${bindingKeyExpr} = ${sql.identifier(prevAlias)}.binding_key`,
-        sql`${timeExpr} < ${sql.identifier(prevAlias)}.${sql.identifier(prevTimeColumn)}`
+        sql`${timeExpr} ${timeOp} ${sql.identifier(prevAlias)}.${sql.identifier(prevTimeColumn)}`
       )
-      const combinedWhere =
-        whereConditions.length === 1
-          ? whereConditions[0]
-          : (and(...whereConditions) as SQL)
+      const combinedWhere = combineWhere(whereConditions)
 
       const eventPathExpr = isSunburst
-        ? sql`${eventExpr} || ${'→'} || ${sql.identifier(prevAlias)}.event_path`
+        ? (isBefore
+            ? sql`${eventExpr} || ${'→'} || ${sql.identifier(prevAlias)}.event_path`
+            : sql`${sql.identifier(prevAlias)}.event_path || ${'→'} || ${eventExpr}`)
         : sql`${eventExpr}`
 
       const lateralSubquery = context.db
@@ -621,7 +586,7 @@ export class FlowQueryBuilder {
         })
         .from(cubeBase.from)
         .where(combinedWhere)
-        .orderBy(sql`${timeExpr} DESC`)
+        .orderBy(sql`${timeExpr} ${orderDir}`)
         .limit(1)
 
       const cte = context.db.$with(alias).as(
@@ -643,78 +608,16 @@ export class FlowQueryBuilder {
   }
 
   /**
-   * Build CTEs for steps AFTER the starting point using LATERAL joins
-   * Uses ORDER BY ... ASC LIMIT 1 to fetch immediate successor via index
-   */
-  private buildAfterCTEsLateral(
-    config: FlowQueryConfig,
-    resolved: ResolvedFlowConfig,
-    context: QueryContext
-  ): WithSubquery[] {
-    const { cubeBase, bindingKeyExpr, timeExpr, eventExpr } = resolved
-    const ctes: WithSubquery[] = []
-    const isSunburst = config.outputMode === 'sunburst'
-
-    for (let depth = 1; depth <= config.stepsAfter; depth++) {
-      const prevAlias = depth === 1 ? 'starting_entities' : `after_step_${depth - 1}`
-      const prevTimeColumn = depth === 1 ? 'start_time' : 'step_time'
-      const alias = `after_step_${depth}`
-
-      const whereConditions: SQL[] = []
-      if (cubeBase.where) {
-        whereConditions.push(cubeBase.where)
-      }
-      whereConditions.push(
-        sql`${bindingKeyExpr} = ${sql.identifier(prevAlias)}.binding_key`,
-        sql`${timeExpr} > ${sql.identifier(prevAlias)}.${sql.identifier(prevTimeColumn)}`
-      )
-      const combinedWhere =
-        whereConditions.length === 1
-          ? whereConditions[0]
-          : (and(...whereConditions) as SQL)
-
-      const eventPathExpr = isSunburst
-        ? sql`${sql.identifier(prevAlias)}.event_path || ${'→'} || ${eventExpr}`
-        : sql`${eventExpr}`
-
-      const lateralSubquery = context.db
-        .select({
-          binding_key: sql`${bindingKeyExpr}`.as('binding_key'),
-          step_time: sql`${timeExpr}`.as('step_time'),
-          event_type: sql`${eventExpr}`.as('event_type'),
-          event_path: eventPathExpr.as('event_path'),
-        })
-        .from(cubeBase.from)
-        .where(combinedWhere)
-        .orderBy(sql`${timeExpr} ASC`)
-        .limit(1)
-
-      const cte = context.db.$with(alias).as(
-        context.db
-          .select({
-            binding_key: sql`e.binding_key`.as('binding_key'),
-            step_time: sql`e.step_time`.as('step_time'),
-            event_type: sql`e.event_type`.as('event_type'),
-            event_path: sql`e.event_path`.as('event_path'),
-          })
-          .from(sql`${sql.identifier(prevAlias)}`)
-          .crossJoinLateral(lateralSubquery.as('e'))
-      )
-
-      ctes.push(cte)
-    }
-
-    return ctes
-  }
-
-  /**
-   * Build CTEs for steps BEFORE the starting point
-   * Each CTE finds the immediate predecessor event for entities from the previous CTE
+   * Build CTEs for steps BEFORE/AFTER the starting point using ROW_NUMBER()
    *
-   * Uses ROW_NUMBER() window function to get exactly the Nth previous event
-   * For sunburst mode, accumulates event_path by prepending to previous path
+   * Direction-parameterised: 'before' finds the immediate predecessor (time `<`
+   * reference, ROW_NUMBER ORDER BY DESC, `before_step_N` aliases, bounded by
+   * `stepsBefore`); 'after' finds the immediate successor (time `>`, ORDER BY ASC,
+   * `after_step_N`, `stepsAfter`). For sunburst mode, accumulates event_path
+   * (prepend for before, append for after).
    */
-  private buildBeforeCTEsWindow(
+  private buildDirectionalCTEsWindow(
+    direction: 'before' | 'after',
     config: FlowQueryConfig,
     resolved: ResolvedFlowConfig,
     context: QueryContext
@@ -723,10 +626,15 @@ export class FlowQueryBuilder {
     const ctes: WithSubquery[] = []
     const isSunburst = config.outputMode === 'sunburst'
 
-    for (let depth = 1; depth <= config.stepsBefore; depth++) {
-      const prevAlias = depth === 1 ? 'starting_entities' : `before_step_${depth - 1}`
+    const isBefore = direction === 'before'
+    const stepBound = isBefore ? config.stepsBefore : config.stepsAfter
+    const timeOp = isBefore ? sql`<` : sql`>`
+    const orderDir = isBefore ? sql`DESC` : sql`ASC`
+
+    for (let depth = 1; depth <= stepBound; depth++) {
+      const prevAlias = depth === 1 ? 'starting_entities' : `${direction}_step_${depth - 1}`
       const prevTimeColumn = depth === 1 ? 'start_time' : 'step_time'
-      const alias = `before_step_${depth}`
+      const alias = `${direction}_step_${depth}`
 
       // Build WHERE conditions
       const whereConditions: SQL[] = []
@@ -734,31 +642,31 @@ export class FlowQueryBuilder {
         whereConditions.push(cubeBase.where)
       }
 
-      // Time constraint: event must be BEFORE the reference time
+      // Time constraint: event must be BEFORE/AFTER the reference time
       whereConditions.push(
-        sql`${timeExpr} < ${sql.identifier(prevAlias)}.${sql.identifier(prevTimeColumn)}`
+        sql`${timeExpr} ${timeOp} ${sql.identifier(prevAlias)}.${sql.identifier(prevTimeColumn)}`
       )
 
-      const combinedWhere =
-        whereConditions.length === 1
-          ? whereConditions[0]
-          : (and(...whereConditions) as SQL)
+      const combinedWhere = combineWhere(whereConditions)
 
       // Build event_path expression for sunburst mode
-      // For before steps, prepend current event to previous path (reverse order)
+      // For before steps, prepend current event to previous path (reverse order);
+      // for after steps, append current event to previous path
       const eventPathExpr = isSunburst
-        ? sql`${eventExpr} || ${'→'} || ${sql.identifier(prevAlias)}.event_path`
+        ? (isBefore
+            ? sql`${eventExpr} || ${'→'} || ${sql.identifier(prevAlias)}.event_path`
+            : sql`${sql.identifier(prevAlias)}.event_path || ${'→'} || ${eventExpr}`)
         : sql`${eventExpr}` // For sankey mode, just use event_type as path
 
       // Build the CTE using a subquery with ROW_NUMBER window function
-      // ROW_NUMBER() OVER (PARTITION BY binding_key ORDER BY time DESC) gives us the Nth previous event
+      // ROW_NUMBER() OVER (PARTITION BY binding_key ORDER BY time DESC/ASC) gives us the Nth previous/following event
       const rankedQuery = context.db
         .select({
           binding_key: sql`${bindingKeyExpr}`.as('binding_key'),
           step_time: sql`${timeExpr}`.as('step_time'),
           event_type: sql`${eventExpr}`.as('event_type'),
           event_path: eventPathExpr.as('event_path'),
-          rn: sql`ROW_NUMBER() OVER (PARTITION BY ${bindingKeyExpr} ORDER BY ${timeExpr} DESC)`.as('rn'),
+          rn: sql`ROW_NUMBER() OVER (PARTITION BY ${bindingKeyExpr} ORDER BY ${timeExpr} ${orderDir})`.as('rn'),
         })
         .from(cubeBase.from)
         .innerJoin(
@@ -767,84 +675,7 @@ export class FlowQueryBuilder {
         )
         .where(combinedWhere)
 
-      // Wrap to filter for rn = 1 (immediate predecessor)
-      const filteredQuery = context.db
-        .select({
-          binding_key: sql`binding_key`.as('binding_key'),
-          step_time: sql`step_time`.as('step_time'),
-          event_type: sql`event_type`.as('event_type'),
-          event_path: sql`event_path`.as('event_path'),
-        })
-        .from(rankedQuery.as('ranked'))
-        .where(sql`rn = 1`)
-
-      ctes.push(context.db.$with(alias).as(filteredQuery))
-    }
-
-    return ctes
-  }
-
-  /**
-   * Build CTEs for steps AFTER the starting point
-   * Each CTE finds the immediate successor event for entities from the previous CTE
-   *
-   * Uses ROW_NUMBER() window function to get exactly the Nth following event
-   * For sunburst mode, accumulates event_path by concatenating with previous path
-   */
-  private buildAfterCTEsWindow(
-    config: FlowQueryConfig,
-    resolved: ResolvedFlowConfig,
-    context: QueryContext
-  ): WithSubquery[] {
-    const { cubeBase, bindingKeyExpr, timeExpr, eventExpr } = resolved
-    const ctes: WithSubquery[] = []
-    const isSunburst = config.outputMode === 'sunburst'
-
-    for (let depth = 1; depth <= config.stepsAfter; depth++) {
-      const prevAlias = depth === 1 ? 'starting_entities' : `after_step_${depth - 1}`
-      const prevTimeColumn = depth === 1 ? 'start_time' : 'step_time'
-      const alias = `after_step_${depth}`
-
-      // Build WHERE conditions
-      const whereConditions: SQL[] = []
-      if (cubeBase.where) {
-        whereConditions.push(cubeBase.where)
-      }
-
-      // Time constraint: event must be AFTER the reference time
-      whereConditions.push(
-        sql`${timeExpr} > ${sql.identifier(prevAlias)}.${sql.identifier(prevTimeColumn)}`
-      )
-
-      const combinedWhere =
-        whereConditions.length === 1
-          ? whereConditions[0]
-          : (and(...whereConditions) as SQL)
-
-      // Build event_path expression for sunburst mode
-      // Concatenates previous path with current event type using arrow separator
-      const eventPathExpr = isSunburst
-        ? sql`${sql.identifier(prevAlias)}.event_path || ${'→'} || ${eventExpr}`
-        : sql`${eventExpr}` // For sankey mode, just use event_type as path
-
-      // Build the CTE using a subquery with ROW_NUMBER window function
-      // ROW_NUMBER() OVER (PARTITION BY binding_key ORDER BY time ASC) gives us the Nth following event
-      const rankedQuery = context.db
-        .select({
-          binding_key: sql`${bindingKeyExpr}`.as('binding_key'),
-          step_time: sql`${timeExpr}`.as('step_time'),
-          event_type: sql`${eventExpr}`.as('event_type'),
-          event_path: eventPathExpr.as('event_path'),
-          rn: sql`ROW_NUMBER() OVER (PARTITION BY ${bindingKeyExpr} ORDER BY ${timeExpr} ASC)`.as('rn'),
-        })
-        .from(cubeBase.from)
-        .innerJoin(
-          sql`${sql.identifier(prevAlias)}`,
-          sql`${bindingKeyExpr} = ${sql.identifier(prevAlias)}.binding_key`
-        )
-        .where(combinedWhere)
-
-      // Wrap to filter for rn = 1 (immediate successor)
+      // Wrap to filter for rn = 1 (immediate predecessor/successor)
       const filteredQuery = context.db
         .select({
           binding_key: sql`binding_key`.as('binding_key'),

--- a/src/server/builders/flow-query-builder.ts
+++ b/src/server/builders/flow-query-builder.ts
@@ -32,6 +32,7 @@ import type {
   LogicalFilter,
 } from '../types'
 import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
+import { hasFlowMode } from '../query-modes'
 import { FilterBuilder } from './filter-builder'
 import { DateTimeBuilder } from './date-time-builder'
 
@@ -67,11 +68,7 @@ export class FlowQueryBuilder {
    * Check if query contains flow configuration
    */
   hasFlow(query: SemanticQuery): boolean {
-    return (
-      query.flow !== undefined &&
-      query.flow.startingStep !== undefined &&
-      query.flow.eventDimension !== undefined
-    )
+    return hasFlowMode(query)
   }
 
   /**

--- a/src/server/builders/flow-query-builder.ts
+++ b/src/server/builders/flow-query-builder.ts
@@ -31,7 +31,7 @@ import type {
   FilterCondition,
   LogicalFilter,
 } from '../types'
-import { resolveSqlExpression } from '../cube-utils'
+import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
 import { FilterBuilder } from './filter-builder'
 import { DateTimeBuilder } from './date-time-builder'
 
@@ -514,12 +514,7 @@ export class FlowQueryBuilder {
     const dimension = cube.dimensions?.[dimName]
     if (!dimension) return null
 
-    // For non-time dimensions, use raw column so Drizzle preserves column type
-    // metadata for proper parameter binding (e.g., UUID columns need type info).
-    // For time dimensions, keep isolated SQL because normalizeDate() returns strings.
-    const fieldExpr = dimension.type === 'time'
-      ? resolveSqlExpression(dimension.sql, context)
-      : (typeof dimension.sql === 'function' ? dimension.sql(context) : dimension.sql)
+    const fieldExpr = resolveFilterFieldExpr(dimension, context)
 
     return this.filterBuilder.buildFilterCondition(
       fieldExpr,

--- a/src/server/builders/funnel-query-builder.ts
+++ b/src/server/builders/funnel-query-builder.ts
@@ -24,6 +24,7 @@ import type {
   LogicalFilter
 } from '../types'
 import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
+import { hasFunnelMode } from '../query-modes'
 import { FilterBuilder } from './filter-builder'
 import { DateTimeBuilder } from './date-time-builder'
 import { JoinPathResolver } from '../resolvers/join-path-resolver'
@@ -72,7 +73,7 @@ export class FunnelQueryBuilder {
    * Check if query contains funnel configuration
    */
   hasFunnel(query: SemanticQuery): boolean {
-    return query.funnel !== undefined && query.funnel.steps.length >= 2
+    return hasFunnelMode(query)
   }
 
   /**

--- a/src/server/builders/funnel-query-builder.ts
+++ b/src/server/builders/funnel-query-builder.ts
@@ -21,7 +21,8 @@ import type {
   SemanticQuery,
   Filter,
   FilterCondition,
-  LogicalFilter
+  LogicalFilter,
+  AnalysisConfigValidationResult
 } from '../types'
 import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
 import { hasFunnelMode } from '../query-modes'
@@ -82,7 +83,7 @@ export class FunnelQueryBuilder {
   validateConfig(
     config: FunnelQueryConfig,
     cubes: Map<string, Cube>
-  ): { isValid: boolean; errors: string[] } {
+  ): AnalysisConfigValidationResult {
     const errors: string[] = []
 
     // Check minimum steps
@@ -591,11 +592,8 @@ export class FunnelQueryBuilder {
       const resolver = new JoinPathResolver(cubes)
       const joinPath = resolver.findPath(baseCube.name, filterCubeName)
       if (!joinPath || joinPath.length === 0) {
-        // No join path exists - cannot filter on this cube
-        console.warn(
-          `Funnel filter: Cannot filter by '${String(filterCubeName).replace(/\n|\r/g, '')}.${String(dimName).replace(/\n|\r/g, '')}' in step using '${String(baseCube.name).replace(/\n|\r/g, '')}'. ` +
-          `No join path found. Filter will be skipped.`
-        )
+        // No join path exists - cannot filter on this cube.
+        // Match flow/retention: silently drop this filter condition by returning null.
         return null
       }
       // Note: The actual JOIN for cross-cube filters is handled in buildStepCTE

--- a/src/server/builders/funnel-query-builder.ts
+++ b/src/server/builders/funnel-query-builder.ts
@@ -23,7 +23,7 @@ import type {
   FilterCondition,
   LogicalFilter
 } from '../types'
-import { resolveSqlExpression } from '../cube-utils'
+import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
 import { FilterBuilder } from './filter-builder'
 import { DateTimeBuilder } from './date-time-builder'
 import { JoinPathResolver } from '../resolvers/join-path-resolver'
@@ -603,12 +603,7 @@ export class FunnelQueryBuilder {
     const dimension = filterCube.dimensions?.[dimName]
     if (!dimension) return null
 
-    // For non-time dimensions, use raw column so Drizzle preserves column type
-    // metadata for proper parameter binding (e.g., UUID columns need type info).
-    // For time dimensions, keep isolated SQL because normalizeDate() returns strings.
-    const fieldExpr = dimension.type === 'time'
-      ? resolveSqlExpression(dimension.sql, context)
-      : (typeof dimension.sql === 'function' ? dimension.sql(context) : dimension.sql)
+    const fieldExpr = resolveFilterFieldExpr(dimension, context)
 
     // Delegate to FilterBuilder which handles all filter operators including date ranges
     return this.filterBuilder.buildFilterCondition(

--- a/src/server/builders/funnel-query-builder.ts
+++ b/src/server/builders/funnel-query-builder.ts
@@ -24,8 +24,9 @@ import type {
   LogicalFilter,
   AnalysisConfigValidationResult
 } from '../types'
-import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
+import { resolveFilterFieldExpr } from '../cube-utils'
 import { hasFunnelMode } from '../query-modes'
+import { combineWhere, resolveBindingKeyExpr, resolveTimeDimensionExpr, type WithSubquery } from './analysis-utils'
 import { FilterBuilder } from './filter-builder'
 import { DateTimeBuilder } from './date-time-builder'
 import { JoinPathResolver } from '../resolvers/join-path-resolver'
@@ -54,12 +55,6 @@ interface ResolvedStep {
   /** Cubes that need to be JOINed for cross-cube filters */
   joinedCubes: JoinedCubeInfo[]
 }
-
-/**
- * Type for CTE objects created by db.$with()
- * These can be used with db.with(...ctes).select().from(cte)
- */
-type WithSubquery = ReturnType<ReturnType<any['$with']>['as']>
 
 export class FunnelQueryBuilder {
   private filterBuilder: FilterBuilder
@@ -429,26 +424,7 @@ export class FunnelQueryBuilder {
     cube: Cube,
     context: QueryContext
   ): SQL {
-    if (typeof config.bindingKey === 'string') {
-      const [, dimName] = config.bindingKey.split('.')
-      const dimension = cube.dimensions?.[dimName]
-      if (!dimension) {
-        throw new Error(t('server.errors.funnel.bindingKeyDimNotFound', { bindingKey: config.bindingKey }))
-      }
-      return resolveSqlExpression(dimension.sql, context) as SQL
-    }
-
-    // Multi-cube binding key - find the mapping for this cube
-    const mapping = config.bindingKey.find(m => m.cube === cube.name)
-    if (!mapping) {
-      throw new Error(t('server.errors.funnel.noBindingKeyMapping', { cubeName: cube.name }))
-    }
-    const [, dimName] = mapping.dimension.split('.')
-    const dimension = cube.dimensions?.[dimName]
-    if (!dimension) {
-      throw new Error(t('server.errors.funnel.bindingKeyMappingDimNotFound', { dimension: mapping.dimension }))
-    }
-    return resolveSqlExpression(dimension.sql, context) as SQL
+    return resolveBindingKeyExpr(config.bindingKey, cube, context, 'server.errors.funnel')
   }
 
   /**
@@ -459,26 +435,7 @@ export class FunnelQueryBuilder {
     cube: Cube,
     context: QueryContext
   ): SQL {
-    if (typeof config.timeDimension === 'string') {
-      const [, dimName] = config.timeDimension.split('.')
-      const dimension = cube.dimensions?.[dimName]
-      if (!dimension) {
-        throw new Error(t('server.errors.funnel.timeDimNotFound', { timeDimension: config.timeDimension }))
-      }
-      return resolveSqlExpression(dimension.sql, context) as SQL
-    }
-
-    // Multi-cube time dimension - find the mapping for this cube
-    const mapping = config.timeDimension.find(m => m.cube === cube.name)
-    if (!mapping) {
-      throw new Error(t('server.errors.funnel.noTimeDimMapping', { cubeName: cube.name }))
-    }
-    const [, dimName] = mapping.dimension.split('.')
-    const dimension = cube.dimensions?.[dimName]
-    if (!dimension) {
-      throw new Error(t('server.errors.funnel.timeDimMappingNotFound', { dimension: mapping.dimension }))
-    }
-    return resolveSqlExpression(dimension.sql, context) as SQL
+    return resolveTimeDimensionExpr(config.timeDimension, cube, context, 'server.errors.funnel')
   }
 
   /**
@@ -676,10 +633,7 @@ export class FunnelQueryBuilder {
 
     // Apply WHERE conditions
     if (whereConditions.length > 0) {
-      const combinedWhere = whereConditions.length === 1
-        ? whereConditions[0]
-        : and(...whereConditions) as SQL
-      stepQuery = stepQuery.where(combinedWhere)
+      stepQuery = stepQuery.where(combineWhere(whereConditions))
     }
 
     // Group by binding key
@@ -747,10 +701,7 @@ export class FunnelQueryBuilder {
 
     // Apply WHERE conditions
     if (whereConditions.length > 0) {
-      const combinedWhere = whereConditions.length === 1
-        ? whereConditions[0]
-        : and(...whereConditions) as SQL
-      stepQuery = stepQuery.where(combinedWhere)
+      stepQuery = stepQuery.where(combineWhere(whereConditions))
     }
 
     // Group by binding key
@@ -790,9 +741,8 @@ export class FunnelQueryBuilder {
           }
         }
 
-        const joinCondition = joinConditions.length === 1
-          ? joinConditions[0]
-          : and(...joinConditions) as SQL
+        // joinConditions always has at least one element here
+        const joinCondition = combineWhere(joinConditions)!
 
         // Get the target cube's table
         const targetCube = joinedCubeInfo.cube

--- a/src/server/builders/retention-query-builder.ts
+++ b/src/server/builders/retention-query-builder.ts
@@ -34,6 +34,7 @@ import type {
 } from '../types'
 import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
 import { hasRetentionMode } from '../query-modes'
+import { combineWhere, type WithSubquery } from './analysis-utils'
 import { FilterBuilder } from './filter-builder'
 import { DateTimeBuilder } from './date-time-builder'
 
@@ -50,11 +51,6 @@ interface ResolvedRetentionConfig {
   /** Resolved breakdown expressions with their dimension names */
   breakdowns: Array<{ dimension: string; expr: SQL }>
 }
-
-/**
- * Type for CTE objects created by db.$with()
- */
-type WithSubquery = ReturnType<ReturnType<any['$with']>['as']>
 
 export class RetentionQueryBuilder {
   private filterBuilder: FilterBuilder
@@ -355,6 +351,13 @@ export class RetentionQueryBuilder {
 
   /**
    * Resolve binding key expression for a cube
+   *
+   * TODO(#850): Not unified with the shared resolveBindingKeyExpr used by
+   * funnel/flow. Retention's variant uses a different i18n leaf-key set
+   * (`server.validation.retention.bindingKeyCubeNotFound` etc., not the
+   * `server.errors.*` keys funnel/flow share), takes an extra `cubes` map for
+   * multi-cube binding-key resolution, and uses `isRetentionMultiCubeBindingKey`
+   * / `extractDimensionName`. Kept separate to preserve exact error messages.
    */
   private resolveBindingKey(
     bindingKey: string | RetentionBindingKeyMapping[],
@@ -525,10 +528,7 @@ export class RetentionQueryBuilder {
 
     // Apply WHERE conditions
     if (whereConditions.length > 0) {
-      const combinedWhere = whereConditions.length === 1
-        ? whereConditions[0]
-        : and(...whereConditions) as SQL
-      groupedQuery = groupedQuery.where(combinedWhere)
+      groupedQuery = groupedQuery.where(combineWhere(whereConditions))
     }
 
     // Group by binding key AND all breakdown dimensions
@@ -644,10 +644,7 @@ export class RetentionQueryBuilder {
 
     // Apply WHERE conditions
     if (whereConditions.length > 0) {
-      const combinedWhere = whereConditions.length === 1
-        ? whereConditions[0]
-        : and(...whereConditions) as SQL
-      query = query.where(combinedWhere)
+      query = query.where(combineWhere(whereConditions))
     }
 
     // Group by to get distinct binding_key/period_number (and breakdown columns) combinations

--- a/src/server/builders/retention-query-builder.ts
+++ b/src/server/builders/retention-query-builder.ts
@@ -29,7 +29,8 @@ import type {
   SemanticQuery,
   Filter,
   FilterCondition,
-  LogicalFilter
+  LogicalFilter,
+  AnalysisConfigValidationResult
 } from '../types'
 import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
 import { hasRetentionMode } from '../query-modes'
@@ -77,7 +78,7 @@ export class RetentionQueryBuilder {
   validateConfig(
     config: RetentionQueryConfig,
     cubes: Map<string, Cube>
-  ): { isValid: boolean; errors: string[] } {
+  ): AnalysisConfigValidationResult {
     const errors: string[] = []
 
     // Engine guard: retention SQL relies on cast/interval syntax that is only

--- a/src/server/builders/retention-query-builder.ts
+++ b/src/server/builders/retention-query-builder.ts
@@ -32,6 +32,7 @@ import type {
   LogicalFilter
 } from '../types'
 import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
+import { hasRetentionMode } from '../query-modes'
 import { FilterBuilder } from './filter-builder'
 import { DateTimeBuilder } from './date-time-builder'
 
@@ -67,11 +68,7 @@ export class RetentionQueryBuilder {
    * Check if query contains retention configuration
    */
   hasRetention(query: SemanticQuery): boolean {
-    return (
-      query.retention !== undefined &&
-      query.retention.timeDimension != null &&
-      query.retention.bindingKey != null
-    )
+    return hasRetentionMode(query)
   }
 
   /**

--- a/src/server/builders/retention-query-builder.ts
+++ b/src/server/builders/retention-query-builder.ts
@@ -31,7 +31,7 @@ import type {
   FilterCondition,
   LogicalFilter
 } from '../types'
-import { resolveSqlExpression } from '../cube-utils'
+import { resolveSqlExpression, resolveFilterFieldExpr } from '../cube-utils'
 import { FilterBuilder } from './filter-builder'
 import { DateTimeBuilder } from './date-time-builder'
 
@@ -462,12 +462,7 @@ export class RetentionQueryBuilder {
     const dimension = filterCube.dimensions?.[dimName]
     if (!dimension) return null
 
-    // For non-time dimensions, use raw column so Drizzle preserves column type
-    // metadata for proper parameter binding (e.g., UUID columns need type info).
-    // For time dimensions, keep isolated SQL because normalizeDate() returns strings.
-    const fieldExpr = dimension.type === 'time'
-      ? resolveSqlExpression(dimension.sql, context)
-      : (typeof dimension.sql === 'function' ? dimension.sql(context) : dimension.sql)
+    const fieldExpr = resolveFilterFieldExpr(dimension, context)
 
     return this.filterBuilder.buildFilterCondition(
       fieldExpr,

--- a/src/server/compiler.ts
+++ b/src/server/compiler.ts
@@ -28,6 +28,7 @@ import { formatSqlString } from '../adapters/utils'
 import { CalculatedMeasureResolver } from './resolvers/calculated-measure-resolver'
 import { validateTemplateSyntax } from './template-substitution'
 import { resolveCubeReference } from './cube-utils'
+import { getActiveQueryModes } from './query-modes'
 import { t } from '../i18n/runtime'
 
 export class SemanticLayerCompiler {
@@ -640,33 +641,7 @@ export class SemanticLayerCompiler {
 type ValidationMode = 'regular' | 'comparison' | 'funnel' | 'flow' | 'retention'
 
 function getActiveValidationModes(query: SemanticQuery): Exclude<ValidationMode, 'regular'>[] {
-  const activeModes: Exclude<ValidationMode, 'regular'>[] = []
-
-  if (query.timeDimensions?.some(td => td.compareDateRange && td.compareDateRange.length >= 2)) {
-    activeModes.push('comparison')
-  }
-
-  if (query.funnel !== undefined && query.funnel.steps?.length >= 2) {
-    activeModes.push('funnel')
-  }
-
-  if (query.flow !== undefined && query.flow.startingStep !== undefined && query.flow.eventDimension !== undefined) {
-    activeModes.push('flow')
-  }
-
-  if (
-    query.retention !== undefined &&
-    query.retention.timeDimension != null &&
-    query.retention.bindingKey != null
-  ) {
-    activeModes.push('retention')
-  }
-
-  if (activeModes.length === 0) {
-    return []
-  }
-
-  return activeModes
+  return getActiveQueryModes(query)
 }
 
 /**

--- a/src/server/cube-utils.ts
+++ b/src/server/cube-utils.ts
@@ -8,6 +8,7 @@ import { and, eq, sql } from 'drizzle-orm'
 import type {
   Cube,
   CubeJoin,
+  Dimension,
   QueryContext,
   MultiCubeQueryContext,
   SqlExpression,
@@ -173,6 +174,26 @@ export function resolveSqlExpression(
 ): AnyColumn | SQL {
   const result = typeof expr === 'function' ? expr(ctx) : expr
   return isolateSqlExpression(result)
+}
+
+/**
+ * Resolve a dimension's SQL expression for use in a filter condition.
+ *
+ * For non-time dimensions, use the raw column so Drizzle preserves column type
+ * metadata for proper parameter binding (e.g. UUID columns need type info) — this
+ * deliberately bypasses isolateSqlExpression. For time dimensions, keep isolated
+ * SQL because normalizeDate() returns strings.
+ *
+ * Centralises the filter-field resolution that was previously copy-pasted across
+ * the filter builder, executor, and funnel/flow/retention builders.
+ */
+export function resolveFilterFieldExpr(
+  dimension: Dimension,
+  ctx: QueryContext
+): AnyColumn | SQL {
+  return dimension.type === 'time'
+    ? resolveSqlExpression(dimension.sql, ctx)
+    : (typeof dimension.sql === 'function' ? dimension.sql(ctx) : dimension.sql)
 }
 
 /**

--- a/src/server/executor.ts
+++ b/src/server/executor.ts
@@ -43,6 +43,7 @@ import { LogicalPlanBuilder, IdentityOptimiser } from './logical-plan'
 import type { PlanOptimiser, QueryNode } from './logical-plan'
 import { DrizzlePlanBuilder } from './physical-plan'
 import { t } from '../i18n/runtime'
+import type { TranslationKey } from '../i18n/types'
 
 type QueryExecutionMode = 'regular' | 'comparison' | 'funnel' | 'flow' | 'retention'
 
@@ -366,24 +367,22 @@ export class QueryExecutor {
   }
 
   /**
-   * Execute a funnel query with caching support
+   * Execute an analysis query (funnel/flow/retention) with caching support.
+   * Wraps the inner execute callback with cache-set logic; the three analysis
+   * modes share identical wrapper behaviour, differing only in which inner
+   * execute method they invoke.
+   *
+   * Cache metadata is intentionally NOT attached here: fresh results across all
+   * query modes (regular, comparison, and analysis) uniformly carry no `cache`
+   * field — only cache *hits* (handled in execute()) carry cache metadata.
    */
-  private async executeFunnelQueryWithCache(
-    cubes: Map<string, Cube>,
-    query: SemanticQuery,
-    securityContext: SecurityContext,
+  private async executeAnalysisQueryWithCache(
+    innerExecute: () => Promise<QueryResult>,
     cacheKey: string | undefined
   ): Promise<QueryResult> {
-    const result = await this.executeFunnelQuery(cubes, query, securityContext)
+    const result = await innerExecute()
     await this.cacheResult(cacheKey, result)
-
-    // Return result with cache metadata (miss - freshly computed)
-    return {
-      ...result,
-      cache: {
-        hit: false
-      }
-    }
+    return result
   }
 
   /**
@@ -396,11 +395,7 @@ export class QueryExecutor {
   ): Promise<QueryResult> {
     const config = query.funnel!
 
-    // Validate funnel configuration
-    const validation = this.funnelQueryBuilder.validateConfig(config, cubes)
-    if (!validation.isValid) {
-      throw new Error(t('server.errors.funnelValidationFailed', { errors: validation.errors.join(', ') }))
-    }
+    // Config already validated once on the execute path via validateQueryForMode.
 
     // Create query context
     const context: QueryContext = {
@@ -448,27 +443,6 @@ export class QueryExecutor {
   }
 
   /**
-   * Execute a flow query with caching support
-   */
-  private async executeFlowQueryWithCache(
-    cubes: Map<string, Cube>,
-    query: SemanticQuery,
-    securityContext: SecurityContext,
-    cacheKey: string | undefined
-  ): Promise<QueryResult> {
-    const result = await this.executeFlowQuery(cubes, query, securityContext)
-    await this.cacheResult(cacheKey, result)
-
-    // Return result with cache metadata (miss - freshly computed)
-    return {
-      ...result,
-      cache: {
-        hit: false
-      }
-    }
-  }
-
-  /**
    * Execute a flow analysis query
    * Produces Sankey diagram data (nodes and links)
    */
@@ -479,11 +453,7 @@ export class QueryExecutor {
   ): Promise<QueryResult> {
     const config = query.flow!
 
-    // Validate flow configuration
-    const validation = this.flowQueryBuilder.validateConfig(config, cubes)
-    if (!validation.isValid) {
-      throw new Error(t('server.errors.flowValidationFailed', { errors: validation.errors.join(', ') }))
-    }
+    // Config already validated once on the execute path via validateQueryForMode.
 
     // Create query context
     const context: QueryContext = {
@@ -528,27 +498,6 @@ export class QueryExecutor {
   }
 
   /**
-   * Execute a retention query with caching support
-   */
-  private async executeRetentionQueryWithCache(
-    cubes: Map<string, Cube>,
-    query: SemanticQuery,
-    securityContext: SecurityContext,
-    cacheKey: string | undefined
-  ): Promise<QueryResult> {
-    const result = await this.executeRetentionQuery(cubes, query, securityContext)
-    await this.cacheResult(cacheKey, result)
-
-    // Return result with cache metadata (miss - freshly computed)
-    return {
-      ...result,
-      cache: {
-        hit: false
-      }
-    }
-  }
-
-  /**
    * Execute a retention analysis query
    * Calculates cohort-based retention rates
    */
@@ -559,11 +508,7 @@ export class QueryExecutor {
   ): Promise<QueryResult> {
     const config = query.retention!
 
-    // Validate retention configuration
-    const validation = this.retentionQueryBuilder.validateConfig(config, cubes)
-    if (!validation.isValid) {
-      throw new Error(t('server.errors.retentionValidationFailed', { errors: validation.errors.join(', ') }))
-    }
+    // Config already validated once on the execute path via validateQueryForMode.
 
     // Create query context
     const context: QueryContext = {
@@ -607,13 +552,22 @@ export class QueryExecutor {
   }
 
   /**
-   * Standard query execution (non-comparison)
-   * This is the core execution logic extracted for use by comparison queries
+   * Standard (regular/non-comparison) query execution.
+   *
+   * This is the single core execution path used by both the regular query mode
+   * and comparison-mode period sub-queries. It always runs the dev-time
+   * security-context validation and propagates planner warnings; the optional
+   * `cacheKey` controls whether the fresh result is written to the cache.
+   *
+   * @param cacheKey - When provided (and a cache provider is configured), the
+   *   fresh result is written to the cache. Pass `undefined` to skip caching
+   *   (e.g. comparison period sub-queries cache at the comparison level).
    */
   private async executeStandardQuery(
     cubes: Map<string, Cube>,
     query: SemanticQuery,
-    securityContext: SecurityContext
+    securityContext: SecurityContext,
+    cacheKey?: string | undefined
   ): Promise<QueryResult> {
     // Create filter cache for parameter deduplication across CTEs
     const filterCache = new FilterCacheManager()
@@ -627,6 +581,12 @@ export class QueryExecutor {
     // Create unified query plan via shared logical pipeline
     const { optimisedPlan } = this.buildRegularQueryArtifacts(cubes, query, context)
     const physicalPlan = this.drizzlePlanBuilder.derivePhysicalPlanContext(optimisedPlan)
+
+    // Validate security context is applied to all cubes in the query plan.
+    // This is a dev-time warning only (no-op outside development unless
+    // DRIZZLE_CUBE_WARN_SECURITY is set), so it is safe to run on every path,
+    // including comparison-mode period sub-queries.
+    this.validateSecurityContext(physicalPlan, context)
 
     // Build the query using unified approach
     const builtQuery = this.drizzlePlanBuilder.build(physicalPlan, query, context)
@@ -670,10 +630,15 @@ export class QueryExecutor {
     // Generate annotations for UI
     const annotation = this.generateAnnotations(physicalPlan, query)
 
-    return {
+    const result: QueryResult = {
       data: filledData,
-      annotation
+      annotation,
+      // Include warnings from query planning (e.g., fan-out without dimensions)
+      warnings: optimisedPlan.warnings?.length ? optimisedPlan.warnings : undefined
     }
+
+    await this.cacheResult(cacheKey, result)
+    return result
   }
 
   /**
@@ -827,38 +792,14 @@ export class QueryExecutor {
     query: SemanticQuery,
     securityContext: SecurityContext
   ): Promise<{ sql: string; params?: any[] }> {
-    // Validate funnel query
-    if (!this.funnelQueryBuilder.hasFunnel(query)) {
-      throw new Error(t('server.errors.invalidFunnelConfig'))
-    }
-
-    const config = query.funnel!
-
-    // Validate funnel configuration
-    const validation = this.funnelQueryBuilder.validateConfig(config, cubes)
-    if (!validation.isValid) {
-      throw new Error(t('server.errors.funnelValidationFailed', { errors: validation.errors.join(', ') }))
-    }
-
-    // Create query context
-    const context: QueryContext = {
-      db: this.dbExecutor.db,
-      schema: this.dbExecutor.schema,
-      securityContext
-    }
-
-    // Build funnel query using Drizzle query builder
-    // The refactored buildFunnelQuery returns a query builder with .toSQL() support
-    const funnelQuery = this.funnelQueryBuilder.buildFunnelQuery(config, cubes, context)
-
-    // Use .toSQL() to get the SQL string and parameters
-    // This now works because buildFunnelQuery returns a Drizzle query builder
-    const sqlObj = funnelQuery.toSQL()
-
-    return {
-      sql: sqlObj.sql,
-      params: sqlObj.params
-    }
+    return this.dryRunAnalysis(query, securityContext, {
+      has: q => this.funnelQueryBuilder.hasFunnel(q),
+      invalidConfigKey: 'server.errors.invalidFunnelConfig',
+      getConfig: q => q.funnel!,
+      validate: config => this.funnelQueryBuilder.validateConfig(config, cubes),
+      validationFailedKey: 'server.errors.funnelValidationFailed',
+      build: (config, context) => this.funnelQueryBuilder.buildFunnelQuery(config, cubes, context)
+    })
   }
 
   /**
@@ -870,36 +811,14 @@ export class QueryExecutor {
     query: SemanticQuery,
     securityContext: SecurityContext
   ): Promise<{ sql: string; params?: any[] }> {
-    // Validate flow query
-    if (!this.flowQueryBuilder.hasFlow(query)) {
-      throw new Error(t('server.errors.invalidFlowConfig'))
-    }
-
-    const config = query.flow!
-
-    // Validate flow configuration
-    const validation = this.flowQueryBuilder.validateConfig(config, cubes)
-    if (!validation.isValid) {
-      throw new Error(t('server.errors.flowValidationFailed', { errors: validation.errors.join(', ') }))
-    }
-
-    // Create query context
-    const context: QueryContext = {
-      db: this.dbExecutor.db,
-      schema: this.dbExecutor.schema,
-      securityContext
-    }
-
-    // Build flow query using Drizzle query builder
-    const flowQuery = this.flowQueryBuilder.buildFlowQuery(config, cubes, context)
-
-    // Use .toSQL() to get the SQL string and parameters
-    const sqlObj = flowQuery.toSQL()
-
-    return {
-      sql: sqlObj.sql,
-      params: sqlObj.params
-    }
+    return this.dryRunAnalysis(query, securityContext, {
+      has: q => this.flowQueryBuilder.hasFlow(q),
+      invalidConfigKey: 'server.errors.invalidFlowConfig',
+      getConfig: q => q.flow!,
+      validate: config => this.flowQueryBuilder.validateConfig(config, cubes),
+      validationFailedKey: 'server.errors.flowValidationFailed',
+      build: (config, context) => this.flowQueryBuilder.buildFlowQuery(config, cubes, context)
+    })
   }
 
   /**
@@ -911,17 +830,44 @@ export class QueryExecutor {
     query: SemanticQuery,
     securityContext: SecurityContext
   ): Promise<{ sql: string; params?: any[] }> {
-    // Validate retention query
-    if (!this.retentionQueryBuilder.hasRetention(query)) {
-      throw new Error(t('server.errors.invalidRetentionConfig'))
+    return this.dryRunAnalysis(query, securityContext, {
+      has: q => this.retentionQueryBuilder.hasRetention(q),
+      invalidConfigKey: 'server.errors.invalidRetentionConfig',
+      getConfig: q => q.retention!,
+      validate: config => this.retentionQueryBuilder.validateConfig(config, cubes),
+      validationFailedKey: 'server.errors.retentionValidationFailed',
+      build: (config, context) => this.retentionQueryBuilder.buildRetentionQuery(config, cubes, context)
+    })
+  }
+
+  /**
+   * Generic dry-run SQL generator for analysis modes (funnel/flow/retention).
+   * The three modes share an identical shape (mode guard → config validation →
+   * build query → toSQL()), differing only in which builder/config they use.
+   */
+  private async dryRunAnalysis<TConfig>(
+    query: SemanticQuery,
+    securityContext: SecurityContext,
+    handlers: {
+      has: (query: SemanticQuery) => boolean
+      invalidConfigKey: TranslationKey
+      getConfig: (query: SemanticQuery) => TConfig
+      validate: (config: TConfig) => { isValid: boolean; errors: string[] }
+      validationFailedKey: TranslationKey
+      build: (config: TConfig, context: QueryContext) => { toSQL(): { sql: string; params: unknown[] } }
+    }
+  ): Promise<{ sql: string; params?: any[] }> {
+    // Validate the query has the expected analysis config
+    if (!handlers.has(query)) {
+      throw new Error(t(handlers.invalidConfigKey))
     }
 
-    const config = query.retention!
+    const config = handlers.getConfig(query)
 
-    // Validate retention configuration
-    const validation = this.retentionQueryBuilder.validateConfig(config, cubes)
+    // Validate the analysis configuration
+    const validation = handlers.validate(config)
     if (!validation.isValid) {
-      throw new Error(t('server.errors.retentionValidationFailed', { errors: validation.errors.join(', ') }))
+      throw new Error(t(handlers.validationFailedKey, { errors: validation.errors.join(', ') }))
     }
 
     // Create query context
@@ -931,11 +877,10 @@ export class QueryExecutor {
       securityContext
     }
 
-    // Build retention query using Drizzle query builder
-    const retentionQuery = this.retentionQueryBuilder.buildRetentionQuery(config, cubes, context)
-
-    // Use .toSQL() to get the SQL string and parameters
-    const sqlObj = retentionQuery.toSQL()
+    // Build the analysis query using its Drizzle query builder, then extract
+    // the SQL string and parameters via .toSQL().
+    const builtQuery = handlers.build(config, context)
+    const sqlObj = builtQuery.toSQL()
 
     return {
       sql: sqlObj.sql,
@@ -1081,89 +1026,17 @@ export class QueryExecutor {
     cacheKey: string | undefined
   ): Promise<QueryResult> {
     const executors: Record<QueryExecutionMode, () => Promise<QueryResult>> = {
-      regular: () => this.executeRegularQueryWithCache(cubes, query, securityContext, cacheKey),
+      regular: () => this.executeStandardQuery(cubes, query, securityContext, cacheKey),
       comparison: () => this.executeComparisonQueryWithCache(cubes, query, securityContext, cacheKey),
-      funnel: () => this.executeFunnelQueryWithCache(cubes, query, securityContext, cacheKey),
-      flow: () => this.executeFlowQueryWithCache(cubes, query, securityContext, cacheKey),
-      retention: () => this.executeRetentionQueryWithCache(cubes, query, securityContext, cacheKey)
+      funnel: () => this.executeAnalysisQueryWithCache(
+        () => this.executeFunnelQuery(cubes, query, securityContext), cacheKey),
+      flow: () => this.executeAnalysisQueryWithCache(
+        () => this.executeFlowQuery(cubes, query, securityContext), cacheKey),
+      retention: () => this.executeAnalysisQueryWithCache(
+        () => this.executeRetentionQuery(cubes, query, securityContext), cacheKey)
     }
 
     return executors[safeKey(mode) as QueryExecutionMode]()
-  }
-
-  private async executeRegularQueryWithCache(
-    cubes: Map<string, Cube>,
-    query: SemanticQuery,
-    securityContext: SecurityContext,
-    cacheKey: string | undefined
-  ): Promise<QueryResult> {
-    // Create filter cache for parameter deduplication across CTEs
-    const filterCache = new FilterCacheManager()
-
-    // Create query context with filter cache
-    const context = this.createQueryContext(securityContext, filterCache, query)
-
-    // Pre-build filter SQL for reuse across CTEs and main query
-    this.preloadFilterCache(query, filterCache, cubes, context)
-
-    // Create query plan via shared logical plan pipeline
-    const { optimisedPlan } = this.buildRegularQueryArtifacts(cubes, query, context)
-    const physicalPlan = this.drizzlePlanBuilder.derivePhysicalPlanContext(optimisedPlan)
-
-    // Validate security context is applied to all cubes in the query plan
-    this.validateSecurityContext(physicalPlan, context)
-
-    // Build the query using unified approach
-    const builtQuery = this.drizzlePlanBuilder.build(physicalPlan, query, context)
-
-    debugSql('query', builtQuery)
-
-    // Execute query - pass numeric field names for selective conversion
-    const numericFields = this.queryBuilder.collectNumericFields(cubes, query)
-    const data = await this.dbExecutor.execute(builtQuery, numericFields)
-
-    // Process time dimension results
-    const mappedData = Array.isArray(data) ? data.map(row => {
-      const mappedRow = { ...row }
-      if (query.timeDimensions) {
-        for (const timeDim of query.timeDimensions) {
-          if (timeDim.dimension in mappedRow) {
-            let dateValue = mappedRow[timeDim.dimension]
-
-            // If we have a date that is not 'T' in the center and Z at the end, we need to fix it
-            if (typeof dateValue === 'string' && dateValue.match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)) {
-              const isoString = dateValue.replace(' ', 'T')
-              const finalIsoString = !isoString.endsWith('Z') && !isoString.includes('+')
-                ? isoString + 'Z'
-                : isoString
-              dateValue = new Date(finalIsoString)
-            }
-
-            // Convert time dimension result using database adapter if required
-            dateValue = this.databaseAdapter.convertTimeDimensionResult(dateValue)
-            mappedRow[timeDim.dimension] = dateValue
-          }
-        }
-      }
-      return mappedRow
-    }) : [data]
-
-    // Apply gap filling for time series if requested
-    const measureNames = query.measures || []
-    const filledData = applyGapFilling(mappedData, query, measureNames)
-
-    // Generate annotations for UI
-    const annotation = this.generateAnnotations(physicalPlan, query)
-
-    const result: QueryResult = {
-      data: filledData,
-      annotation,
-      // Include warnings from query planning (e.g., fan-out without dimensions)
-      warnings: optimisedPlan.warnings?.length ? optimisedPlan.warnings : undefined
-    }
-
-    await this.cacheResult(cacheKey, result)
-    return result
   }
 
   private async cacheResult(cacheKey: string | undefined, result: QueryResult): Promise<void> {

--- a/src/server/executor.ts
+++ b/src/server/executor.ts
@@ -25,7 +25,7 @@ import type {
   RLSSetupFn
 } from './types'
 
-import { resolveSqlExpression, safeKey } from './cube-utils'
+import { resolveSqlExpression, resolveFilterFieldExpr, safeKey } from './cube-utils'
 import { FilterCacheManager, getFilterKey, getTimeDimensionFilterKey, flattenFilters } from './filter-cache'
 import { generateCacheKey } from './cache-utils'
 import { DrizzleSqlBuilder } from './physical-plan/drizzle-sql-builder'
@@ -1339,12 +1339,7 @@ export class QueryExecutor {
           continue
         }
 
-        // For non-time dimensions, use raw column so Drizzle preserves column type
-        // metadata for proper parameter binding (e.g., UUID columns need type info).
-        // For time dimensions, keep isolated SQL because normalizeDate() returns strings.
-        const fieldExpr = dimension.type === 'time'
-          ? resolveSqlExpression(dimension.sql, context)
-          : (typeof dimension.sql === 'function' ? dimension.sql(context) : dimension.sql)
+        const fieldExpr = resolveFilterFieldExpr(dimension, context)
         const filterSQL = this.queryBuilder.buildFilterConditionPublic(
           fieldExpr,
           filter.operator,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,18 @@
 export { SemanticLayerCompiler } from './compiler'
 export { QueryExecutor } from './executor'
 
+// Query-mode detection (single source of truth for comparison/funnel/flow/retention)
+export {
+  detectQueryMode,
+  detectQueryModes,
+  getActiveQueryModes,
+  hasComparisonMode,
+  hasFunnelMode,
+  hasFlowMode,
+  hasRetentionMode
+} from './query-modes'
+export type { QueryMode, QueryModeFlags } from './query-modes'
+
 // Export unified query building
 export { LogicalPlanner } from './logical-plan'
 export { DrizzleSqlBuilder } from './physical-plan'

--- a/src/server/logical-plan/logical-planner.ts
+++ b/src/server/logical-plan/logical-planner.ts
@@ -118,15 +118,6 @@ export class LogicalPlanner {
   }
 
   /**
-   * Build query-level path hints (Cube-style) from all query members:
-   * measures, dimensions, time dimensions, filters, and order-by.
-   * These hints guide path selection toward the semantic query grain.
-   */
-  private collectPathHintCubes(query: SemanticQuery): Set<string> {
-    return this.analyzeCubeUsage(query)
-  }
-
-  /**
    * Recursively extract cube names from filters (handles logical filters)
    */
   private extractCubeNamesFromFilter(filter: any, cubesUsed: Set<string>): void {
@@ -193,29 +184,6 @@ export class LogicalPlanner {
         // and shouldn't trigger pre-aggregation CTEs
       }
     }
-  }
-
-  /**
-   * Choose the primary cube based on query analysis
-   * Uses a consistent strategy to avoid measure order dependencies
-   *
-   * Delegates to analyzePrimaryCubeSelection() for the actual logic,
-   * ensuring a single source of truth for primary cube selection.
-   */
-  choosePrimaryCube(cubeNames: string[], query: SemanticQuery, cubes?: Map<string, Cube>): string {
-    // For single cube, return immediately
-    if (cubeNames.length === 1) {
-      return cubeNames[0]
-    }
-
-    // Without cubes map, fall back to alphabetical
-    if (!cubes) {
-      return [...cubeNames].sort()[0]
-    }
-
-    // Use the detailed analysis method and extract just the selected cube
-    const analysis = this.analyzePrimaryCubeSelection(cubeNames, query, cubes)
-    return analysis.selectedCube
   }
 
   /**
@@ -313,7 +281,7 @@ export class LogicalPlanner {
     }
 
     // Rust-style hinting: include all query member cubes to drive path selection.
-    const preferredPathCubes = this.collectPathHintCubes(query)
+    const preferredPathCubes = this.analyzeCubeUsage(query)
 
     // Pre-identify cubes that will become CTEs (hasMany relationships with measures)
     // IMPORTANT: We must NOT give "already processed" preference to CTE'd cubes because
@@ -684,7 +652,7 @@ export class LogicalPlanner {
     }>
   } | null {
     const resolver = this.getResolver(cubes)
-    const preferredPathCubes = this.collectPathHintCubes(query)
+    const preferredPathCubes = this.analyzeCubeUsage(query)
 
     const joinPath = preferredPathCubes.size > 0
       ? resolver.findPathPreferring(primaryCube.name, targetCubeName, preferredPathCubes, new Set())
@@ -1404,7 +1372,7 @@ export class LogicalPlanner {
   ): JoinPathAnalysis {
     // Use the resolver for BFS path finding (cached, optimized)
     const resolver = this.getResolver(cubes)
-    const preferredPathCubes = query ? this.collectPathHintCubes(query) : new Set<string>()
+    const preferredPathCubes = query ? this.analyzeCubeUsage(query) : new Set<string>()
     const preferredSelection: PreferredPathSelection | null = preferredPathCubes.size > 0
       ? resolver.findPathPreferringDetailed(fromCube, toCube, preferredPathCubes)
       : null

--- a/src/server/query-modes.ts
+++ b/src/server/query-modes.ts
@@ -1,0 +1,81 @@
+/**
+ * Query-mode detection
+ *
+ * Single source of truth for deciding which analysis mode a SemanticQuery targets
+ * (comparison / funnel / flow / retention, else regular). Previously these predicates
+ * were copy-pasted — and had drifted — across the compiler, the per-mode builders,
+ * and the HTTP adapter dry-run helper. Centralising them here keeps execution
+ * routing, validation, and dry-run reporting consistent.
+ */
+
+import type { SemanticQuery } from './types'
+
+export type QueryMode = 'regular' | 'comparison' | 'funnel' | 'flow' | 'retention'
+
+export interface QueryModeFlags {
+  comparison: boolean
+  funnel: boolean
+  flow: boolean
+  retention: boolean
+}
+
+/** A query is a comparison when a time dimension carries a compareDateRange with ≥2 ranges. */
+export function hasComparisonMode(query: SemanticQuery): boolean {
+  return query.timeDimensions?.some(td =>
+    td.compareDateRange && td.compareDateRange.length >= 2
+  ) ?? false
+}
+
+/**
+ * A query is a funnel when it has a funnel config with ≥2 steps.
+ * Null-safe on `steps` — a `funnel: {}` payload must not throw here.
+ */
+export function hasFunnelMode(query: SemanticQuery): boolean {
+  return query.funnel != null && (query.funnel.steps?.length ?? 0) >= 2
+}
+
+/** A query is a flow when it has a flow config with a startingStep and eventDimension. */
+export function hasFlowMode(query: SemanticQuery): boolean {
+  return (
+    query.flow != null &&
+    query.flow.startingStep !== undefined &&
+    query.flow.eventDimension !== undefined
+  )
+}
+
+/** A query is a retention when it has a retention config with a timeDimension and bindingKey. */
+export function hasRetentionMode(query: SemanticQuery): boolean {
+  return (
+    query.retention != null &&
+    query.retention.timeDimension != null &&
+    query.retention.bindingKey != null
+  )
+}
+
+/** Per-mode booleans for a query. */
+export function detectQueryModes(query: SemanticQuery): QueryModeFlags {
+  return {
+    comparison: hasComparisonMode(query),
+    funnel: hasFunnelMode(query),
+    flow: hasFlowMode(query),
+    retention: hasRetentionMode(query)
+  }
+}
+
+/**
+ * Active non-regular modes for a query, in execution-priority order
+ * (comparison, funnel, flow, retention). A well-formed query matches at most one.
+ */
+export function getActiveQueryModes(query: SemanticQuery): Exclude<QueryMode, 'regular'>[] {
+  const modes: Exclude<QueryMode, 'regular'>[] = []
+  if (hasComparisonMode(query)) modes.push('comparison')
+  if (hasFunnelMode(query)) modes.push('funnel')
+  if (hasFlowMode(query)) modes.push('flow')
+  if (hasRetentionMode(query)) modes.push('retention')
+  return modes
+}
+
+/** The single priority mode for a query, or 'regular' when none match. */
+export function detectQueryMode(query: SemanticQuery): QueryMode {
+  return getActiveQueryModes(query)[0] ?? 'regular'
+}

--- a/src/server/types/flow.ts
+++ b/src/server/types/flow.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Filter } from './query'
+import type { AnalysisConfigValidationResult } from './validation'
 
 // ============================================================================
 // Flow Query Configuration
@@ -171,12 +172,12 @@ export interface RawFlowLinkRow {
 
 /**
  * Flow validation result
+ *
+ * Alias of the shared {@link AnalysisConfigValidationResult} used by all
+ * analysis-mode builders. Kept as a named export for backwards compatibility
+ * with existing consumers.
  */
-export interface FlowValidationResult {
-  isValid: boolean
-  errors: string[]
-  warnings: string[]
-}
+export type FlowValidationResult = AnalysisConfigValidationResult
 
 // ============================================================================
 // Constants

--- a/src/server/types/index.ts
+++ b/src/server/types/index.ts
@@ -24,6 +24,9 @@ export * from './metadata'
 // Query analysis types
 export * from './analysis'
 
+// Analysis-mode config validation types
+export * from './validation'
+
 // Utility functions and helpers
 export * from './utils'
 

--- a/src/server/types/validation.ts
+++ b/src/server/types/validation.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared validation types for analysis-mode config validation
+ */
+
+/**
+ * Result of validating an analysis-mode config (funnel, flow, retention).
+ *
+ * `warnings` is optional — flow analysis surfaces non-fatal warnings, while
+ * funnel and retention only produce errors (and omit the field entirely).
+ */
+export interface AnalysisConfigValidationResult {
+  isValid: boolean
+  errors: string[]
+  warnings?: string[]
+}

--- a/tests/database-adapters.test.ts
+++ b/tests/database-adapters.test.ts
@@ -9,16 +9,20 @@ import { SQLiteAdapter } from '../src/server/adapters/sqlite-adapter'
 import { PostgresAdapter } from '../src/server/adapters/postgres-adapter'
 import { SingleStoreAdapter } from '../src/server/adapters/singlestore-adapter'
 
-// Helper to get SQL string from SQL object
+// Helper to get SQL string from SQL object.
+// Recurses into nested SQL objects (e.g. COALESCE(AVG(x), 0) where AVG(x) is its
+// own SQL fragment) so the rendered text reflects the full expression.
 function getSqlString(sqlObj: any): string {
-  if (sqlObj.toSQL) {
-    return sqlObj.toSQL().sql
-  }
+  if (sqlObj == null) return ''
+  if (typeof sqlObj === 'string') return sqlObj
   if (sqlObj.queryChunks) {
-    return sqlObj.queryChunks.map((c: any) =>
-      typeof c === 'string' ? c : c.value?.toString() || ''
-    ).join('')
+    return sqlObj.queryChunks.map((c: any) => {
+      if (typeof c === 'string') return c
+      if (c?.queryChunks) return getSqlString(c) // nested SQL fragment
+      return c?.value?.toString() || ''
+    }).join('')
   }
+  if (sqlObj.value !== undefined) return sqlObj.value.toString()
   return String(sqlObj)
 }
 

--- a/tests/flow-query.test.ts
+++ b/tests/flow-query.test.ts
@@ -320,7 +320,7 @@ describe('Server-Side Flow Queries', () => {
       }
       const highDepthResult = builder.validateConfig(highDepth, cubes)
       expect(highDepthResult.isValid).toBe(true)
-      expect(highDepthResult.warnings.some(w => w.includes('High step depth'))).toBe(true)
+      expect(highDepthResult.warnings?.some(w => w.includes('High step depth'))).toBe(true)
     })
 
     it('should transform results correctly', () => {

--- a/tests/query-modes.test.ts
+++ b/tests/query-modes.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Query-mode detection unit tests
+ * Covers the single source of truth in src/server/query-modes.ts, including the
+ * null-safety regression (a partial `funnel: {}` payload must not throw).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  detectQueryMode,
+  getActiveQueryModes,
+  hasFunnelMode,
+  hasFlowMode,
+  hasRetentionMode,
+  hasComparisonMode
+} from '../src/server/query-modes'
+import type { SemanticQuery } from '../src/server/types'
+
+describe('query-modes', () => {
+  it('detects a regular query when no mode config is present', () => {
+    const query: SemanticQuery = { measures: ['Orders.count'] }
+    expect(detectQueryMode(query)).toBe('regular')
+    expect(getActiveQueryModes(query)).toEqual([])
+  })
+
+  it('detects funnel with >= 2 steps', () => {
+    const query = {
+      funnel: { steps: [{}, {}] }
+    } as unknown as SemanticQuery
+    expect(hasFunnelMode(query)).toBe(true)
+    expect(detectQueryMode(query)).toBe('funnel')
+  })
+
+  it('does NOT throw on a partial funnel payload (regression for #850)', () => {
+    // Previously the funnel builder used query.funnel.steps.length (no ?.),
+    // which threw a raw TypeError on `funnel: {}` before validation could run.
+    const query = { funnel: {} } as unknown as SemanticQuery
+    expect(() => hasFunnelMode(query)).not.toThrow()
+    expect(hasFunnelMode(query)).toBe(false)
+    expect(detectQueryMode(query)).toBe('regular')
+  })
+
+  it('does not treat a single-step funnel as a funnel', () => {
+    const query = { funnel: { steps: [{}] } } as unknown as SemanticQuery
+    expect(hasFunnelMode(query)).toBe(false)
+  })
+
+  it('detects flow via startingStep + eventDimension', () => {
+    const query = {
+      flow: { bindingKey: 'X.id', startingStep: {}, eventDimension: 'X.event' }
+    } as unknown as SemanticQuery
+    expect(hasFlowMode(query)).toBe(true)
+    expect(detectQueryMode(query)).toBe('flow')
+  })
+
+  it('detects retention via timeDimension + bindingKey', () => {
+    const query = {
+      retention: { timeDimension: 'X.ts', bindingKey: 'X.id' }
+    } as unknown as SemanticQuery
+    expect(hasRetentionMode(query)).toBe(true)
+    expect(detectQueryMode(query)).toBe('retention')
+  })
+
+  it('detects comparison via compareDateRange with >= 2 ranges', () => {
+    const query = {
+      timeDimensions: [{ dimension: 'X.ts', compareDateRange: ['last 7 days', 'last 14 days'] }]
+    } as unknown as SemanticQuery
+    expect(hasComparisonMode(query)).toBe(true)
+    expect(detectQueryMode(query)).toBe('comparison')
+  })
+
+  it('comparison takes priority in the active-modes ordering', () => {
+    const query = {
+      timeDimensions: [{ dimension: 'X.ts', compareDateRange: ['a', 'b'] }],
+      funnel: { steps: [{}, {}] }
+    } as unknown as SemanticQuery
+    expect(getActiveQueryModes(query)).toEqual(['comparison', 'funnel'])
+    expect(detectQueryMode(query)).toBe('comparison')
+  })
+})


### PR DESCRIPTION
Works through #850 — consolidating the mechanical duplication in the semantic layer. Quality-only (no behavior change) **except** three intentional consistency/bug fixes called out below. Each row of the issue is a separate commit; the full multi-engine test matrix (Postgres / MySQL / SQLite) is green.

## Commits (one per issue row)

| # | Commit | What | Net lines |
|---|--------|------|-----------|
| 1 | adapters base-class defaults | Move identical/near-identical methods into `BaseDatabaseAdapter` as overridable defaults + `nullToZero`/`caseInsensitiveLike`/`regexCondition` hooks | ~−770 |
| 7 | `resolveFilterFieldExpr` helper | Centralise the isolateSqlExpression filter-bypass ternary (was copy-pasted in 5 files) | ~−5 |
| 4 | unify query-mode detection | New `query-modes.ts` single source of truth; **fixes** a `funnel: {}` TypeError crash | ~+125 |
| 5 | validation shapes + levenshtein | Shared `AnalysisConfigValidationResult`; dedupe `levenshteinDistance`; **fix** funnel filter-resolution to `return null` like flow/retention | ~−30 |
| 2 | analysis-builder consolidation | New `analysis-utils.ts` (`combineWhere`, `WithSubquery`, `resolveBindingKeyExpr`/`resolveTimeDimensionExpr`); collapse flow before/after mirror CTEs via `direction` param | ~−100 |
| 6 | remove dead code | Drop `collectPathHintCubes` alias + unused `choosePrimaryCube` | ~−35 |
| 3 | consolidate executor paths | Merge duplicate query/dry-run/cache-wrapper methods; **fix** comparison-mode skipping `validateSecurityContext` + losing planner warnings; remove double validation; uniform cache metadata | ~−127 |

**Net: ~917 insertions / 1844 deletions (~−927 lines)** across 28 files.

## Intentional behavior fixes (not pure refactor)
- **funnel `{}` crash**: the funnel builder checked `query.funnel.steps.length` (not null-safe) while the compiler used `?.length`, so a partial `funnel: {}` payload threw a raw `TypeError` before validation. Detection is now uniformly null-safe (commit 4).
- **funnel silent filter skip**: funnel `console.warn`-ed and dropped an unresolvable filter (silent data difference vs flow/retention, which `return null`). Now consistent (commit 5).
- **comparison missing security warning + planner warnings**: comparison/standard execution went through the non-cached path that skipped `validateSecurityContext` and dropped `optimisedPlan.warnings`; the merged executor path now applies both regardless of caching (commit 3).

## Deferred (intentionally, per the issue's semver caveat)
- Item 6 candidates that are **exported from `drizzle-cube/server`** (`DatabaseAdapter.supportsLateralJoins()`, the write-only `DatabaseCapabilities` flags) — removal is a typed breaking change; left in place with evidence rather than deleted. The optimiser pipeline is owned by the separate logical-plan issue.
- Item 2's sunburst/sankey UNION-arm compression, the FilterBuilder cross-cube extension, and retention's `resolveBindingKey` (divergent i18n keys + multi-cube handling) — left for a follow-up with a `TODO(#850)`.

## Testing
- `npm run typecheck` ✅  · `npm run lint` ✅
- Postgres: **2348 passed** · SQLite: **2308 passed / 40 skipped** · MySQL: **2335 passed / 13 skipped**
- Added `tests/query-modes.test.ts` (incl. the `funnel: {}` regression) and made the adapter unit-test SQL renderer recurse into nested fragments.

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)
