### PR TITLE
refactor: standardise & dedupe chart components (#861)

### DIFF
--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-gate
-description: Use before finishing or opening a PR for a large / multi-file change to drizzle-cube, to ensure code quality does not regress. Runs `fallow audit` (complexity, duplication, dead code, circular deps scoped to the diff, blocking only on issues the change *introduces*) plus a `madge` circular-dependency snapshot. Use when the user says "check quality", "make sure quality doesn't regress", "is this PR clean", or after a refactor touching many files.
+description: Use before finishing or opening a PR for a large / multi-file change to drizzle-cube, to ensure code quality does not regress. Runs `fallow audit` (complexity, duplication, dead code, circular deps scoped to the diff, reporting issues the change *introduces*) plus a `madge` circular-dependency snapshot. Report-only — it always exits 0 and never blocks; read the verdict as advice. Use when the user says "check quality", "make sure quality doesn't regress", "is this PR clean", or after a refactor touching many files.
 ---
 
 # Quality Regression Gate
@@ -39,10 +39,16 @@ npm run quality -- --base main
 npm run quality -- --base "$(git merge-base main HEAD)"
 ```
 
-**Exit code 0 = pass, 1 = fail.** A failure means the change introduced new complexity,
-duplication, dead code, or a circular dependency. The verdict ignores inherited findings —
-watch for the line `audit gate excluded N inherited findings`, which confirms pre-existing
-debt was not counted against you.
+**Report-only: `npm run quality` always exits 0 — it never fails the build.** The wrapper
+runs `fallow audit` and then forces a clean exit, so the gate is advisory, not blocking.
+You still read the **`verdict`** (`pass` / `warn` / `fail`) and the introduced findings from
+the report — treat a `fail` verdict as "worth a look / mention in the PR," not as a hard
+stop. The verdict ignores inherited findings — watch for the line
+`audit gate excluded N inherited findings`, which confirms pre-existing debt was not counted
+against the change.
+
+> Want it to block again? Drop the `sh -c '… ; exit 0'` wrapper in the `quality` script
+> (`package.json`) back to plain `fallow audit`, or add `--ci` for a CI-friendly failing gate.
 
 ### Reading the result precisely (JSON)
 
@@ -58,10 +64,10 @@ npm run quality --silent -- --format json
   "verdict": "pass" | "warn" | "fail",
   "attribution": {
     "gate": "new-only",
-    "dead_code_introduced": 0,      // <- these *_introduced fields are what blocks
+    "dead_code_introduced": 0,      // <- these *_introduced fields drive the verdict
     "complexity_introduced": 0,
     "duplication_introduced": 0,
-    "dead_code_inherited": 8,       // <- inherited: reported, never blocks
+    "dead_code_inherited": 8,       // <- inherited: reported, never affects the verdict
     "complexity_inherited": 17,
     "duplication_inherited": 93
   }
@@ -99,10 +105,11 @@ npm run quality:graph                                      # writes dependency-g
 This is an exploratory tool, not a regression check — its output has no introduced-vs-inherited
 attribution and will always show the full inherited backlog.
 
-## Acting on a FAIL
+## Acting on a `fail` verdict
 
-Only the introduced findings need fixing. fallow prints each with a file:line and a docs
-link. Typical fixes:
+The gate is report-only, so a `fail` verdict doesn't stop anything — but the introduced
+findings are still worth addressing (or calling out in the PR). fallow prints each with a
+file:line and a docs link. Typical fixes:
 
 | Introduced finding | What to do |
 |--------------------|------------|
@@ -128,8 +135,11 @@ get a green gate on a finding you actually introduced.
 ## How it's wired
 
 - `fallow@2.95.0` and `madge@8.0.0` are pinned devDependencies (`package.json`).
-- Scripts: `quality`, `quality:circular`, `quality:health`, `quality:graph`.
+- Scripts: `quality`, `quality:health`, `quality:graph`.
+- The `quality` script is `sh -c 'fallow audit "$@"; exit 0' --` — it runs the full audit
+  (forwarding any `-- …` args) but always exits 0, making the gate **report-only / advisory**.
+  To restore a blocking gate, change it back to plain `fallow audit` (or `fallow audit --ci`).
 - No `fallow.config` — defaults are used intentionally. The gate is `new-only`, so inherited
   debt (the 5 false-positive unused devDeps, 20 circular deps, existing duplication) is
-  reported but never blocks. Add a config only if you later want tunable thresholds or to
-  exclude `dist`/generated dirs from duplication.
+  reported but never affects the verdict. Add a config only if you later want tunable
+  thresholds or to exclude `dist`/generated dirs from duplication.

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",
     "lint": "eslint 'src/**/*.{ts,tsx}' 'tests/**/*.ts' 'perf/**/*.ts'",
     "lint:fix": "eslint 'src/**/*.{ts,tsx}' 'tests/**/*.ts' 'perf/**/*.ts' --fix",
-    "quality": "fallow audit",
+    "quality": "sh -c 'fallow audit \"$@\"; exit 0' --",
     "quality:health": "fallow health",
     "quality:graph": "npx madge --image dependency-graph.svg --extensions ts,tsx src",
     "perf": "tsx perf/run.ts",

--- a/src/client/charts/chartConfigHelpers.ts
+++ b/src/client/charts/chartConfigHelpers.ts
@@ -1,0 +1,101 @@
+import type { ChartAvailabilityContext, ChartAvailability, DisplayOptionConfig } from './chartConfigs'
+
+/**
+ * Shared building blocks for chart `*.config.ts` files.
+ *
+ * Most chart configs repeated the same `isAvailable` guard and the same
+ * display-option definitions (target line, Y-axis format, stacking, …).
+ * These factories centralise that boilerplate so each chart config only
+ * declares what is genuinely unique to it.
+ */
+
+/**
+ * Standard availability rule shared by most chart types: at least one measure
+ * and at least one dimension (regular or time) must be selected.
+ */
+export function requiresMeasureAndDimension({
+  measureCount,
+  dimensionCount
+}: ChartAvailabilityContext): ChartAvailability {
+  if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
+  if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
+  return { available: true }
+}
+
+/**
+ * Availability rule for charts that only need a single measure (KPI-style
+ * charts and gauges): at least one measure, no dimension requirement.
+ */
+export function requiresMeasure({ measureCount }: ChartAvailabilityContext): ChartAvailability {
+  if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
+  return { available: true }
+}
+
+/** Target-line display option (single value or comma-separated spread). */
+export const targetDisplayOption: DisplayOptionConfig = {
+  key: 'target',
+  label: 'chart.option.target.label',
+  type: 'string',
+  placeholder: 'e.g., 100 or 50,75 for spread',
+  description: 'chart.option.target.description'
+}
+
+/** Connect-nulls toggle for line/area charts. */
+export const connectNullsDisplayOption: DisplayOptionConfig = {
+  key: 'connectNulls',
+  label: 'chart.option.connectNulls.label',
+  type: 'boolean',
+  defaultValue: false,
+  description: 'chart.option.connectNulls.description'
+}
+
+/** Left Y-axis numeric format control (dual-axis charts). */
+export const leftYAxisFormatDisplayOption: DisplayOptionConfig = {
+  key: 'leftYAxisFormat',
+  label: 'chart.option.leftYAxisFormat.label',
+  type: 'axisFormat',
+  description: 'chart.option.leftYAxisFormat.description'
+}
+
+/** Right Y-axis numeric format control (dual-axis charts). */
+export const rightYAxisFormatDisplayOption: DisplayOptionConfig = {
+  key: 'rightYAxisFormat',
+  label: 'chart.option.rightYAxisFormat.label',
+  type: 'axisFormat',
+  description: 'chart.option.rightYAxisFormat.description'
+}
+
+/**
+ * Single value-format control used by charts that only have one numeric scale
+ * (pie, radar, radial bar, treemap). Stored under `leftYAxisFormat` for
+ * backward compatibility with existing saved configs.
+ */
+export function valueFormatDisplayOption(
+  description = 'chart.option.valueFormat.description'
+): DisplayOptionConfig {
+  return {
+    key: 'leftYAxisFormat',
+    label: 'chart.option.valueFormat.label',
+    type: 'axisFormat',
+    description
+  }
+}
+
+/**
+ * Stacking-mode select shared by bar and area charts. `description` differs
+ * per chart (bar vs area series wording).
+ */
+export function stackTypeDisplayOption(description: string): DisplayOptionConfig {
+  return {
+    key: 'stackType',
+    label: 'chart.option.stacking.label',
+    type: 'select',
+    defaultValue: 'none',
+    options: [
+      { value: 'none', label: 'chart.option.accentBorder.none' },
+      { value: 'normal', label: 'chart.option.stacking.stacked' },
+      { value: 'percent', label: 'chart.option.stacking.percent' }
+    ],
+    description
+  }
+}

--- a/src/client/components/charts/AreaChart.config.ts
+++ b/src/client/components/charts/AreaChart.config.ts
@@ -1,4 +1,12 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import {
+  requiresMeasureAndDimension,
+  stackTypeDisplayOption,
+  connectNullsDisplayOption,
+  targetDisplayOption,
+  leftYAxisFormatDisplayOption,
+  rightYAxisFormatDisplayOption
+} from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the area chart type
@@ -7,11 +15,7 @@ export const areaChartConfig: ChartTypeConfig = {
   label: 'chart.area.label',
   description: 'chart.area.description',
   useCase: 'chart.area.useCase',
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   dropZones: [
     {
       key: 'xAxis',
@@ -41,43 +45,10 @@ export const areaChartConfig: ChartTypeConfig = {
   ],
   displayOptions: ['showLegend', 'showGrid', 'showTooltip', 'showAllXLabels', 'hideHeader'],
   displayOptionsConfig: [
-    {
-      key: 'stackType',
-      label: 'chart.option.stacking.label',
-      type: 'select',
-      defaultValue: 'none',
-      options: [
-        { value: 'none', label: 'chart.option.accentBorder.none' },
-        { value: 'normal', label: 'chart.option.stacking.stacked' },
-        { value: 'percent', label: 'chart.option.stacking.percent' }
-      ],
-      description: 'chart.configText.how_to_stack_multiple_area_series'
-    },
-    {
-      key: 'connectNulls',
-      label: 'chart.option.connectNulls.label',
-      type: 'boolean',
-      defaultValue: false,
-      description: 'chart.option.connectNulls.description'
-    },
-    {
-      key: 'target',
-      label: 'chart.option.target.label',
-      type: 'string',
-      placeholder: 'e.g., 100 or 50,75 for spread',
-      description: 'chart.option.target.description'
-    },
-    {
-      key: 'leftYAxisFormat',
-      label: 'chart.option.leftYAxisFormat.label',
-      type: 'axisFormat',
-      description: 'chart.option.leftYAxisFormat.description'
-    },
-    {
-      key: 'rightYAxisFormat',
-      label: 'chart.option.rightYAxisFormat.label',
-      type: 'axisFormat',
-      description: 'chart.option.rightYAxisFormat.description'
-    }
+    stackTypeDisplayOption('chart.configText.how_to_stack_multiple_area_series'),
+    connectNullsDisplayOption,
+    targetDisplayOption,
+    leftYAxisFormatDisplayOption,
+    rightYAxisFormatDisplayOption
   ]
 }

--- a/src/client/components/charts/AreaChart.tsx
+++ b/src/client/components/charts/AreaChart.tsx
@@ -1,12 +1,22 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import { useTranslation } from '../../hooks/useTranslation'
-import { ComposedChart, Area, Line, XAxis, YAxis, CartesianGrid, Legend } from 'recharts'
+import { ComposedChart, Area, XAxis, CartesianGrid } from 'recharts'
 import ChartContainer from './ChartContainer'
 import ChartTooltip from './ChartTooltip'
 import AngledXAxisTick from './AngledXAxisTick'
-import { CHART_COLORS, CHART_MARGINS } from '../../utils/chartConstants'
-import { transformChartDataWithSeries, formatAxisValue } from '../../utils/chartUtils'
-import { parseTargetValues, spreadTargetValues } from '../../utils/targetUtils'
+import { ChartEmptyState, ChartConfigError, ChartRenderError } from './ChartStates'
+import { resolveChartAxisFields } from './chartAxisResolution'
+import {
+  getDualAxisInfo,
+  getYAxisChartMargins,
+  withTargetData,
+  renderDualYAxes,
+  renderChartTargetLines,
+  makeCartesianTooltipFormatter,
+  renderHoverLegend
+} from './chartScaffolding'
+import { CHART_COLORS } from '../../utils/chartConstants'
+import { transformChartDataWithSeries } from '../../utils/chartUtils'
 import { useCubeFieldLabel } from '../../hooks/useCubeFieldLabel'
 import type { ChartProps } from '../../types'
 
@@ -24,7 +34,35 @@ const AreaChart = React.memo(function AreaChart({
   const [hoveredLegend, setHoveredLegend] = useState<string | null>(null)
   // Use specialized hook to avoid re-renders from unrelated context changes
   const getFieldLabel = useCubeFieldLabel()
-  
+
+  // Resolve + validate axis fields (hooks-first to satisfy React rules)
+  const { xAxisField, yAxisFields, seriesFields, errorCode } = useMemo(
+    () => resolveChartAxisFields(chartConfig),
+    [chartConfig]
+  )
+
+  // Dual Y-axis support: extract yAxisAssignment from chartConfig
+  const yAxisAssignment = useMemo(() =>
+    chartConfig?.yAxisAssignment || {},
+    [chartConfig?.yAxisAssignment]
+  )
+
+  // Use shared function to transform data and handle series
+  // (empty arrays when config is invalid — early returns happen after hooks)
+  const { data: chartData, seriesKeys } = useMemo(() => {
+    if (errorCode || !data || data.length === 0 || !xAxisField) {
+      return { data: [], seriesKeys: [] }
+    }
+    return transformChartDataWithSeries(
+      data,
+      xAxisField,
+      yAxisFields,
+      queryObject,
+      seriesFields,
+      getFieldLabel
+    )
+  }, [data, xAxisField, yAxisFields, queryObject, seriesFields, getFieldLabel, errorCode])
+
   try {
     // Determine stacking from stackType (new) or stacked (legacy)
     const stackType = displayConfig?.stackType ?? (displayConfig?.stacked ? 'normal' : 'none')
@@ -45,64 +83,12 @@ const AreaChart = React.memo(function AreaChart({
     const rightYAxisFormat = displayConfig?.rightYAxisFormat
 
     if (!data || data.length === 0) {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-text-muted" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.noData')}</div>
-            <div className="dc:text-xs text-dc-text-secondary">{t('chart.runtime.noDataHint.area')}</div>
-          </div>
-        </div>
-      )
+      return <ChartEmptyState height={height} hint={t('chart.runtime.noDataHint.area')} />
     }
 
-    // Validate chartConfig - support both legacy and new formats
-    let xAxisField: string
-    let yAxisFields: string[]
-    let seriesFields: string[] = []
-    
-    if (chartConfig?.xAxis && chartConfig?.yAxis) {
-      // New format
-      xAxisField = Array.isArray(chartConfig.xAxis) ? chartConfig.xAxis[0] : chartConfig.xAxis
-      yAxisFields = Array.isArray(chartConfig.yAxis) ? chartConfig.yAxis : [chartConfig.yAxis]
-      seriesFields = chartConfig.series || []
-    } else if (chartConfig?.x && chartConfig?.y) {
-      // Legacy format
-      xAxisField = chartConfig.x
-      yAxisFields = Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y]
-    } else {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-warning" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.configError')}</div>
-            <div className="dc:text-xs">{t('chart.runtime.configErrorHint.axisInvalid')}</div>
-          </div>
-        </div>
-      )
+    if (errorCode) {
+      return <ChartConfigError height={height} hint={t(`chart.runtime.configErrorHint.${errorCode}`)} />
     }
-
-    if (!xAxisField || !yAxisFields || yAxisFields.length === 0) {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-warning" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.configError')}</div>
-            <div className="dc:text-xs">{t('chart.runtime.configErrorHint.axisFields')}</div>
-          </div>
-        </div>
-      )
-    }
-
-    // Use shared function to transform data and handle series
-    const { data: chartData, seriesKeys } = transformChartDataWithSeries(
-      data,
-      xAxisField,
-      yAxisFields,
-      queryObject,
-      seriesFields,
-      getFieldLabel
-    )
-
-    // Dual Y-axis support: extract yAxisAssignment from chartConfig
-    const yAxisAssignment = chartConfig?.yAxisAssignment || {}
 
     // Build mapping from series key (label) to original field name
     const seriesKeyToField: Record<string, string> = {}
@@ -111,12 +97,9 @@ const AreaChart = React.memo(function AreaChart({
       seriesKeyToField[label] = field
     })
 
-    // Determine if we need a right Y-axis
-    const hasRightAxis = yAxisFields.some((field) => yAxisAssignment[field] === 'right')
-
-    // Get fields for left and right axes for labels
-    const leftAxisFields = yAxisFields.filter((f) => (yAxisAssignment[f] || 'left') === 'left')
-    const rightAxisFields = yAxisFields.filter((f) => yAxisAssignment[f] === 'right')
+    // Dual Y-axis derivation + margins (shared scaffolding)
+    const axisInfo = getDualAxisInfo(yAxisFields, yAxisAssignment)
+    const { hasRightAxis } = axisInfo
 
     // Disable stacking when dual Y-axis is used (areas on different axes can't be stacked)
     const effectiveShouldStack = shouldStack && !hasRightAxis
@@ -126,34 +109,19 @@ const AreaChart = React.memo(function AreaChart({
     const showLegend = safeDisplayConfig.showLegend
 
     // Use custom chart margins with extra space for Y-axis labels
-    const chartMargins = {
-      ...CHART_MARGINS,
-      left: 40, // Space for left Y-axis label
-      right: hasRightAxis ? 40 : 20 // Extra space for right Y-axis label if needed
-    }
-    
+    const chartMargins = getYAxisChartMargins(hasRightAxis)
+
     // Process target values and add to chart data
-    const targetValues = parseTargetValues(displayConfig?.target || '')
-    const spreadTargets = spreadTargetValues(targetValues, chartData.length)
-    
-    // Add target data to chart data if targets exist
-    let enhancedChartData = chartData
-    if (spreadTargets.length > 0) {
-      enhancedChartData = chartData.map((dataPoint, index) => ({
-        ...dataPoint,
-        __target: spreadTargets[index] || null
-      }))
-    }
-    
+    const { spreadTargets, enhancedChartData } = withTargetData(chartData, displayConfig?.target)
+
     // Validate transformed data
     if (!chartData || chartData.length === 0) {
       return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-text-muted" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.noValidData')}</div>
-            <div className="dc:text-xs text-dc-text-secondary">No valid data points for area chart after transformation</div>
-          </div>
-        </div>
+        <ChartEmptyState
+          height={height}
+          titleKey="chart.runtime.noValidData"
+          hint="No valid data points for area chart after transformation"
+        />
       )
     }
 
@@ -165,84 +133,25 @@ const AreaChart = React.memo(function AreaChart({
         <ComposedChart data={enhancedChartData} margin={chartMargins} stackOffset={stackOffset} accessibilityLayer={false}>
           {safeDisplayConfig.showGrid && <CartesianGrid strokeDasharray="3 3" style={{ pointerEvents: 'none' }} />}
           <XAxis dataKey="name" type="category" tick={<AngledXAxisTick />} height={60} interval={showAllXLabels ? 0 : undefined} />
-          <YAxis
-            yAxisId="left"
-            orientation="left"
-            tick={{ fontSize: 12 }}
-            tickFormatter={
-              effectiveIsPercentStack
-                ? (v) => `${(v * 100).toFixed(0)}%`
-                : leftYAxisFormat
-                  ? (value) => formatAxisValue(value, leftYAxisFormat)
-                  : undefined
-            }
-            domain={effectiveIsPercentStack ? [0, 1] : undefined}
-            label={
-              effectiveIsPercentStack
-                ? undefined
-                : leftAxisFields.length > 0
-                  ? {
-                      value: leftYAxisFormat?.label || getFieldLabel(leftAxisFields[0]),
-                      angle: -90,
-                      position: 'left',
-                      style: { textAnchor: 'middle', fontSize: '12px' }
-                    }
-                  : undefined
-            }
-          />
-          {hasRightAxis && (
-            <YAxis
-              yAxisId="right"
-              orientation="right"
-              tick={{ fontSize: 12 }}
-              tickFormatter={rightYAxisFormat ? (value) => formatAxisValue(value, rightYAxisFormat) : undefined}
-              label={
-                rightAxisFields.length > 0
-                  ? {
-                      value: rightYAxisFormat?.label || getFieldLabel(rightAxisFields[0]),
-                      angle: 90,
-                      position: 'right',
-                      style: { textAnchor: 'middle', fontSize: '12px' }
-                    }
-                  : undefined
-              }
-            />
-          )}
+          {renderDualYAxes(axisInfo, getFieldLabel, leftYAxisFormat, rightYAxisFormat, effectiveIsPercentStack)}
           {safeDisplayConfig.showTooltip && (
             <ChartTooltip
-              formatter={(value: any, name: any) => {
-                // Handle null values in tooltip
-                if (value === null || value === undefined) {
-                  return ['No data', name]
-                }
-                if (name === 'Target') {
-                  // Use left Y-axis format for target values
-                  return [formatAxisValue(value, leftYAxisFormat), 'Target Value']
-                }
-                // Format as percentage when using percent stacking
-                if (effectiveIsPercentStack && typeof value === 'number') {
-                  return [`${(value * 100).toFixed(1)}%`, name]
-                }
-                // Determine which axis format to use based on series name
-                const originalField = seriesKeyToField[name]
-                const axisId = originalField && yAxisAssignment[originalField] === 'right' ? 'right' : 'left'
-                const formatConfig = axisId === 'right' ? rightYAxisFormat : leftYAxisFormat
-                return [formatAxisValue(value, formatConfig), name]
-              }}
+              formatter={makeCartesianTooltipFormatter({
+                leftYAxisFormat,
+                rightYAxisFormat,
+                yAxisAssignment,
+                resolveField: (name) => seriesKeyToField[name],
+                isPercentStack: effectiveIsPercentStack
+              })}
             />
           )}
-          {showLegend && (
-            <Legend 
-              wrapperStyle={{ fontSize: '12px', paddingTop: '10px' }}
-              iconType="rect"
-              iconSize={8}
-              layout="horizontal"
-              align="center"
-              verticalAlign="bottom"
-              onMouseEnter={(o) => setHoveredLegend(String(o.dataKey || ''))}
-              onMouseLeave={() => setHoveredLegend(null)}
-            />
-          )}
+          {renderHoverLegend({
+            show: showLegend,
+            iconType: 'rect',
+            paddingTop: 10,
+            onHover: setHoveredLegend,
+            onLeave: () => setHoveredLegend(null)
+          })}
           {seriesKeys.map((seriesKey, index) => {
             // Look up the original field name to get its axis assignment
             const originalField = seriesKeyToField[seriesKey]
@@ -312,48 +221,12 @@ const AreaChart = React.memo(function AreaChart({
               />
             )
           })}
-          {spreadTargets.length > 0 && (
-            <>
-              {/* White background line */}
-              <Line
-                type="monotone"
-                dataKey="__target"
-                yAxisId="left"
-                stroke="#ffffff"
-                strokeWidth={2}
-                dot={false}
-                activeDot={false}
-                connectNulls={false}
-              />
-              {/* Grey dashed line on top */}
-              <Line
-                type="monotone"
-                dataKey="__target"
-                yAxisId="left"
-                name="Target"
-                stroke="#8B5CF6"
-                strokeWidth={2}
-                strokeDasharray="2 3"
-                dot={false}
-                activeDot={false}
-                connectNulls={false}
-              />
-            </>
-          )}
+          {renderChartTargetLines(spreadTargets)}
         </ComposedChart>
       </ChartContainer>
     )
   } catch (error) {
-    // 'AreaChart rendering error
-    return (
-      <div className="dc:flex dc:flex-col dc:items-center dc:justify-center dc:w-full text-dc-error dc:p-4" style={{ height }}>
-        <div className="dc:text-center">
-          <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.chartError', { chartType: 'Area Chart' })}</div>
-          <div className="dc:text-xs dc:mb-2">{error instanceof Error ? error.message : t('chart.runtime.unknownError')}</div>
-          <div className="dc:text-xs text-dc-text-muted">{t('chart.runtime.checkConfig')}</div>
-        </div>
-      </div>
-    )
+    return <ChartRenderError height={height} chartType="Area Chart" error={error} />
   }
 })
 

--- a/src/client/components/charts/BarChart.config.ts
+++ b/src/client/components/charts/BarChart.config.ts
@@ -1,4 +1,11 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import {
+  requiresMeasureAndDimension,
+  stackTypeDisplayOption,
+  targetDisplayOption,
+  leftYAxisFormatDisplayOption,
+  rightYAxisFormatDisplayOption
+} from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the bar chart type
@@ -8,11 +15,7 @@ export const barChartConfig: ChartTypeConfig = {
   description: 'chart.bar.description',
   useCase: 'chart.bar.useCase',
   clickableElements: { bar: true },
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   dropZones: [
     {
       key: 'xAxis',
@@ -42,36 +45,9 @@ export const barChartConfig: ChartTypeConfig = {
   ],
   displayOptions: ['showLegend', 'showGrid', 'showTooltip', 'showAllXLabels', 'hideHeader'],
   displayOptionsConfig: [
-    {
-      key: 'stackType',
-      label: 'chart.option.stacking.label',
-      type: 'select',
-      defaultValue: 'none',
-      options: [
-        { value: 'none', label: 'chart.option.accentBorder.none' },
-        { value: 'normal', label: 'chart.option.stacking.stacked' },
-        { value: 'percent', label: 'chart.option.stacking.percent' }
-      ],
-      description: 'chart.configText.how_to_stack_multiple_bar_series'
-    },
-    {
-      key: 'target',
-      label: 'chart.option.target.label',
-      type: 'string',
-      placeholder: 'e.g., 100 or 50,75 for spread',
-      description: 'chart.option.target.description'
-    },
-    {
-      key: 'leftYAxisFormat',
-      label: 'chart.option.leftYAxisFormat.label',
-      type: 'axisFormat',
-      description: 'chart.option.leftYAxisFormat.description'
-    },
-    {
-      key: 'rightYAxisFormat',
-      label: 'chart.option.rightYAxisFormat.label',
-      type: 'axisFormat',
-      description: 'chart.option.rightYAxisFormat.description'
-    }
+    stackTypeDisplayOption('chart.configText.how_to_stack_multiple_bar_series'),
+    targetDisplayOption,
+    leftYAxisFormatDisplayOption,
+    rightYAxisFormatDisplayOption
   ]
 }

--- a/src/client/components/charts/BarChart.tsx
+++ b/src/client/components/charts/BarChart.tsx
@@ -1,12 +1,22 @@
 import React, { useState, useMemo } from 'react'
 import { useTranslation } from '../../hooks/useTranslation'
-import { ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Cell, Legend } from 'recharts'
+import { ComposedChart, Bar, XAxis, CartesianGrid, Cell } from 'recharts'
 import ChartContainer from './ChartContainer'
 import ChartTooltip from './ChartTooltip'
 import AngledXAxisTick from './AngledXAxisTick'
-import { CHART_COLORS, POSITIVE_COLOR, NEGATIVE_COLOR, CHART_MARGINS } from '../../utils/chartConstants'
-import { transformChartDataWithSeries, isValidNumericValue, formatAxisValue } from '../../utils/chartUtils'
-import { parseTargetValues, spreadTargetValues } from '../../utils/targetUtils'
+import { ChartEmptyState, ChartConfigError, ChartRenderError } from './ChartStates'
+import { resolveChartAxisFields } from './chartAxisResolution'
+import {
+  getDualAxisInfo,
+  getYAxisChartMargins,
+  withTargetData,
+  renderDualYAxes,
+  renderChartTargetLines,
+  makeCartesianTooltipFormatter,
+  renderHoverLegend
+} from './chartScaffolding'
+import { CHART_COLORS, POSITIVE_COLOR, NEGATIVE_COLOR } from '../../utils/chartConstants'
+import { transformChartDataWithSeries, isValidNumericValue } from '../../utils/chartUtils'
 import { useCubeFieldLabel } from '../../hooks/useCubeFieldLabel'
 import type { ChartProps } from '../../types'
 
@@ -42,37 +52,15 @@ const BarChart = React.memo(function BarChart({
   const leftYAxisFormat = displayConfig?.leftYAxisFormat
   const rightYAxisFormat = displayConfig?.rightYAxisFormat
 
-  // Validate chartConfig - support both legacy and new formats
-  // Do validation but don't early return yet (hooks must come first)
-  const { xAxisField, yAxisFields, seriesFields, configError } = useMemo(() => {
-    let xAxisField: string | undefined
-    let yAxisFields: string[] = []
-    let seriesFields: string[] = []
-    let configError: string | null = null
-
-    if (chartConfig?.xAxis && chartConfig?.yAxis) {
-      // New format
-      xAxisField = Array.isArray(chartConfig.xAxis) ? chartConfig.xAxis[0] : chartConfig.xAxis
-      yAxisFields = Array.isArray(chartConfig.yAxis) ? chartConfig.yAxis : [chartConfig.yAxis]
-      seriesFields = chartConfig.series || []
-    } else if (chartConfig?.x && chartConfig?.y) {
-      // Legacy format
-      xAxisField = chartConfig.x
-      yAxisFields = Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y]
-    } else {
-      configError = 'Invalid or missing chart axis configuration'
-    }
-
-    if (!configError && (!xAxisField || !yAxisFields || yAxisFields.length === 0)) {
-      configError = 'Missing required X-axis or Y-axis fields'
-    }
-
-    return { xAxisField, yAxisFields, seriesFields, configError }
-  }, [chartConfig])
+  // Resolve + validate axis fields (hooks-first; early returns happen after all hooks)
+  const { xAxisField, yAxisFields, seriesFields, errorCode } = useMemo(
+    () => resolveChartAxisFields(chartConfig),
+    [chartConfig]
+  )
 
   // Transform data (will be empty arrays if config is invalid)
   const { data: transformedData, seriesKeys } = useMemo(() => {
-    if (configError || !data || data.length === 0 || !xAxisField) {
+    if (errorCode || !data || data.length === 0 || !xAxisField) {
       return { data: [], seriesKeys: [] }
     }
     return transformChartDataWithSeries(
@@ -83,7 +71,7 @@ const BarChart = React.memo(function BarChart({
       seriesFields,
       getFieldLabel
     )
-  }, [data, xAxisField, yAxisFields, queryObject, seriesFields, getFieldLabel, configError])
+  }, [data, xAxisField, yAxisFields, queryObject, seriesFields, getFieldLabel, errorCode])
 
   // Dual Y-axis support: extract yAxisAssignment from chartConfig (memoized to prevent object recreation)
   const yAxisAssignment = useMemo(() =>
@@ -101,12 +89,9 @@ const BarChart = React.memo(function BarChart({
     return mapping
   }, [yAxisFields, getFieldLabel])
 
-  // Determine if we need a right Y-axis
-  const hasRightAxis = yAxisFields.some((field) => yAxisAssignment[field] === 'right')
-
-  // Get fields for left and right axes for labels
-  const leftAxisFields = yAxisFields.filter((f) => (yAxisAssignment[f] || 'left') === 'left')
-  const rightAxisFields = yAxisFields.filter((f) => yAxisAssignment[f] === 'right')
+  // Dual Y-axis derivation (shared scaffolding)
+  const axisInfo = getDualAxisInfo(yAxisFields, yAxisAssignment)
+  const { hasRightAxis } = axisInfo
 
   // Null handling: Filter out data points where ALL measure values are null
   // This prevents rendering empty bars and makes the chart clearer
@@ -125,25 +110,11 @@ const BarChart = React.memo(function BarChart({
   // Now handle early returns AFTER all hooks
   try {
     if (!data || data.length === 0) {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-text-muted" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.noData')}</div>
-            <div className="dc:text-xs text-dc-text-secondary">No data points to display in bar chart</div>
-          </div>
-        </div>
-      )
+      return <ChartEmptyState height={height} hint={t('chart.runtime.noDataHint.bar')} />
     }
 
-    if (configError) {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-warning" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.configError')}</div>
-            <div className="dc:text-xs">{configError}</div>
-          </div>
-        </div>
-      )
+    if (errorCode) {
+      return <ChartConfigError height={height} hint={t(`chart.runtime.configErrorHint.${errorCode}`)} />
     }
 
     // Determine stack offset for percentage stacking
@@ -170,34 +141,19 @@ const BarChart = React.memo(function BarChart({
     const showLegend = safeDisplayConfig.showLegend
 
     // Use custom chart margins with extra space for Y-axis labels
-    const chartMargins = {
-      ...CHART_MARGINS,
-      left: 40, // Space for left Y-axis label
-      right: hasRightAxis ? 40 : 20 // Extra space for right Y-axis label if needed
-    }
-    
+    const chartMargins = getYAxisChartMargins(hasRightAxis)
+
     // Process target values and add to chart data
-    const targetValues = parseTargetValues(displayConfig?.target || '')
-    const spreadTargets = spreadTargetValues(targetValues, chartData.length)
-    
-    // Add target data to chart data if targets exist
-    let enhancedChartData = chartData
-    if (spreadTargets.length > 0) {
-      enhancedChartData = chartData.map((dataPoint, index) => ({
-        ...dataPoint,
-        __target: spreadTargets[index] || null
-      }))
-    }
-    
+    const { spreadTargets, enhancedChartData } = withTargetData(chartData, displayConfig?.target)
+
     // Validate transformed data
     if (!chartData || chartData.length === 0) {
       return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-text-muted" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.noValidData')}</div>
-            <div className="dc:text-xs text-dc-text-secondary">No valid data points for bar chart after transformation</div>
-          </div>
-        </div>
+        <ChartEmptyState
+          height={height}
+          titleKey="chart.runtime.noValidData"
+          hint="No valid data points for bar chart after transformation"
+        />
       )
     }
 
@@ -215,84 +171,25 @@ const BarChart = React.memo(function BarChart({
             height={60}
             interval={showAllXLabels ? 0 : undefined}
           />
-          <YAxis
-            yAxisId="left"
-            orientation="left"
-            tick={{ fontSize: 12 }}
-            tickFormatter={
-              effectiveIsPercentStack
-                ? (v) => `${(v * 100).toFixed(0)}%`
-                : leftYAxisFormat
-                  ? (value) => formatAxisValue(value, leftYAxisFormat)
-                  : undefined
-            }
-            domain={effectiveIsPercentStack ? [0, 1] : undefined}
-            label={
-              effectiveIsPercentStack
-                ? undefined
-                : leftAxisFields.length > 0
-                  ? {
-                      value: leftYAxisFormat?.label || getFieldLabel(leftAxisFields[0]),
-                      angle: -90,
-                      position: 'left',
-                      style: { textAnchor: 'middle', fontSize: '12px' }
-                    }
-                  : undefined
-            }
-          />
-          {hasRightAxis && (
-            <YAxis
-              yAxisId="right"
-              orientation="right"
-              tick={{ fontSize: 12 }}
-              tickFormatter={rightYAxisFormat ? (value) => formatAxisValue(value, rightYAxisFormat) : undefined}
-              label={
-                rightAxisFields.length > 0
-                  ? {
-                      value: rightYAxisFormat?.label || getFieldLabel(rightAxisFields[0]),
-                      angle: 90,
-                      position: 'right',
-                      style: { textAnchor: 'middle', fontSize: '12px' }
-                    }
-                  : undefined
-              }
-            />
-          )}
+          {renderDualYAxes(axisInfo, getFieldLabel, leftYAxisFormat, rightYAxisFormat, effectiveIsPercentStack)}
           {safeDisplayConfig.showTooltip && (
             <ChartTooltip
-              formatter={(value: any, name: any) => {
-                // Handle null values in tooltip
-                if (value === null || value === undefined) {
-                  return ['No data', name]
-                }
-                if (name === 'Target') {
-                  // Use left Y-axis format for target values
-                  return [formatAxisValue(value, leftYAxisFormat), 'Target Value']
-                }
-                // Format as percentage when using percent stacking
-                if (effectiveIsPercentStack && typeof value === 'number') {
-                  return [`${(value * 100).toFixed(1)}%`, name]
-                }
-                // Determine which axis format to use based on series name
-                const originalField = seriesKeyToField[name]
-                const axisId = originalField && yAxisAssignment[originalField] === 'right' ? 'right' : 'left'
-                const formatConfig = axisId === 'right' ? rightYAxisFormat : leftYAxisFormat
-                return [formatAxisValue(value, formatConfig), name]
-              }}
+              formatter={makeCartesianTooltipFormatter({
+                leftYAxisFormat,
+                rightYAxisFormat,
+                yAxisAssignment,
+                resolveField: (name) => seriesKeyToField[name],
+                isPercentStack: effectiveIsPercentStack
+              })}
             />
           )}
-          {showLegend && (
-            <Legend 
-              wrapperStyle={{ fontSize: '12px', paddingTop: '25px' }}
-              iconType="rect"
-              iconSize={8}
-              layout="horizontal"
-              align="center"
-              verticalAlign="bottom"
-              onMouseEnter={(o) => setHoveredLegend(String(o.dataKey || ''))}
-              onMouseLeave={() => setHoveredLegend(null)}
-            />
-          )}
+          {renderHoverLegend({
+            show: showLegend,
+            iconType: 'rect',
+            paddingTop: 25,
+            onHover: setHoveredLegend,
+            onLeave: () => setHoveredLegend(null)
+          })}
           {seriesKeys.map((seriesKey, index) => {
             // Look up the original field name to get its axis assignment
             const originalField = seriesKeyToField[seriesKey]
@@ -349,34 +246,7 @@ const BarChart = React.memo(function BarChart({
               </Bar>
             )
           })}
-          {spreadTargets.length > 0 && (
-            <>
-              {/* White background line */}
-              <Line
-                type="monotone"
-                dataKey="__target"
-                yAxisId="left"
-                stroke="#ffffff"
-                strokeWidth={2}
-                dot={false}
-                activeDot={false}
-                connectNulls={false}
-              />
-              {/* Grey dashed line on top */}
-              <Line
-                type="monotone"
-                dataKey="__target"
-                yAxisId="left"
-                name="Target"
-                stroke="#8B5CF6"
-                strokeWidth={2}
-                strokeDasharray="2 3"
-                dot={false}
-                activeDot={false}
-                connectNulls={false}
-              />
-            </>
-          )}
+          {renderChartTargetLines(spreadTargets)}
           </ComposedChart>
         </ChartContainer>
         {skippedCount > 0 && (
@@ -387,16 +257,7 @@ const BarChart = React.memo(function BarChart({
       </div>
     )
   } catch (error) {
-    // 'BarChart rendering error
-    return (
-      <div className="dc:flex dc:flex-col dc:items-center dc:justify-center dc:w-full text-dc-error dc:p-4" style={{ height }}>
-        <div className="dc:text-center">
-          <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.chartError', { chartType: 'Bar Chart' })}</div>
-          <div className="dc:text-xs dc:mb-2">{error instanceof Error ? error.message : t('chart.runtime.unknownError')}</div>
-          <div className="dc:text-xs text-dc-text-muted">{t('chart.runtime.checkConfig')}</div>
-        </div>
-      </div>
-    )
+    return <ChartRenderError height={height} chartType="Bar Chart" error={error} />
   }
 })
 

--- a/src/client/components/charts/BoxPlotChart.config.ts
+++ b/src/client/components/charts/BoxPlotChart.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasureAndDimension } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the box plot chart type
@@ -7,11 +8,7 @@ export const boxPlotChartConfig: ChartTypeConfig = {
   label: 'chart.boxPlot.label',
   description: 'chart.boxPlot.description',
   useCase: 'chart.boxPlot.useCase',
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   displayOptions: ['hideHeader'],
   dropZones: [
     {

--- a/src/client/components/charts/ChartStates.tsx
+++ b/src/client/components/charts/ChartStates.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { useTranslation } from '../../hooks/useTranslation'
+
+/**
+ * Shared guard/state components for chart rendering.
+ *
+ * Cartesian charts (bar, line, area, pie, …) all duplicated the same
+ * centred flex blocks for their empty / config-error / render-error states,
+ * differing only in the hint text. These components own the duplicated wrapper
+ * JSX; each chart supplies its own already-resolved `hint` (a translation key
+ * resolved via `t()`, or a literal string) so per-chart messaging is preserved.
+ */
+
+interface ChartStateProps {
+  height?: string | number
+  /** Already-resolved hint text (caller resolves its own i18n key) */
+  hint?: React.ReactNode
+}
+
+/**
+ * Empty / no-data state (muted styling). `titleKey` defaults to the generic
+ * "No data available" heading but can be overridden (e.g. for the post-transform
+ * "No valid data" state).
+ */
+export function ChartEmptyState({
+  height,
+  hint,
+  titleKey = 'chart.runtime.noData'
+}: ChartStateProps & { titleKey?: string }) {
+  const { t } = useTranslation()
+  return (
+    <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-text-muted" style={{ height }}>
+      <div className="dc:text-center">
+        <div className="dc:text-sm dc:font-semibold dc:mb-1">{t(titleKey)}</div>
+        {hint != null && <div className="dc:text-xs text-dc-text-secondary">{hint}</div>}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Invalid-configuration state (warning styling). Title is always
+ * "Configuration Error"; the chart supplies a hint describing what is missing.
+ */
+export function ChartConfigError({ height, hint }: ChartStateProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-warning" style={{ height }}>
+      <div className="dc:text-center">
+        <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.configError')}</div>
+        {hint != null && <div className="dc:text-xs">{hint}</div>}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Render-error state (error styling), used in chart `catch` blocks.
+ */
+export function ChartRenderError({
+  height,
+  chartType,
+  error
+}: {
+  height?: string | number
+  /** Display name used in the "{chartType} Error" heading */
+  chartType: string
+  error: unknown
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="dc:flex dc:flex-col dc:items-center dc:justify-center dc:w-full text-dc-error dc:p-4" style={{ height }}>
+      <div className="dc:text-center">
+        <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.chartError', { chartType })}</div>
+        <div className="dc:text-xs dc:mb-2">{error instanceof Error ? error.message : t('chart.runtime.unknownError')}</div>
+        <div className="dc:text-xs text-dc-text-muted">{t('chart.runtime.checkConfig')}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/client/components/charts/GaugeChart.config.ts
+++ b/src/client/components/charts/GaugeChart.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasure } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the gauge chart type
@@ -9,10 +10,7 @@ export const gaugeChartConfig: ChartTypeConfig = {
   useCase: 'chart.gauge.useCase',
   clickableElements: {},
   displayOptions: ['hideHeader'],
-  isAvailable: ({ measureCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasure,
   dropZones: [
     {
       key: 'yAxis',

--- a/src/client/components/charts/KpiDelta.config.ts
+++ b/src/client/components/charts/KpiDelta.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasureAndDimension } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the KPI Delta chart type
@@ -7,11 +8,7 @@ export const kpiDeltaConfig: ChartTypeConfig = {
   label: 'chart.kpiDelta.label',
   description: 'chart.kpiDelta.description',
   useCase: 'chart.kpiDelta.useCase',
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   dropZones: [
     {
       key: 'yAxis',

--- a/src/client/components/charts/KpiNumber.config.ts
+++ b/src/client/components/charts/KpiNumber.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasure } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the KPI Number chart type
@@ -7,10 +8,7 @@ export const kpiNumberConfig: ChartTypeConfig = {
   label: 'chart.kpiNumber.label',
   description: 'chart.kpiNumber.description',
   useCase: 'chart.kpiNumber.useCase',
-  isAvailable: ({ measureCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasure,
   dropZones: [
     {
       key: 'yAxis',

--- a/src/client/components/charts/KpiText.config.ts
+++ b/src/client/components/charts/KpiText.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasure } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the KPI Text chart type
@@ -7,10 +8,7 @@ export const kpiTextConfig: ChartTypeConfig = {
   label: 'chart.kpiText.label',
   description: 'chart.kpiText.description',
   useCase: 'chart.kpiText.useCase',
-  isAvailable: ({ measureCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasure,
   dropZones: [
     {
       key: 'yAxis',

--- a/src/client/components/charts/LineChart.config.ts
+++ b/src/client/components/charts/LineChart.config.ts
@@ -1,4 +1,11 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import {
+  requiresMeasureAndDimension,
+  connectNullsDisplayOption,
+  targetDisplayOption,
+  leftYAxisFormatDisplayOption,
+  rightYAxisFormatDisplayOption
+} from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the line chart type
@@ -8,11 +15,7 @@ export const lineChartConfig: ChartTypeConfig = {
   description: 'chart.line.description',
   useCase: 'chart.line.useCase',
   clickableElements: { point: true },
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   dropZones: [
     {
       key: 'xAxis',
@@ -42,20 +45,8 @@ export const lineChartConfig: ChartTypeConfig = {
   ],
   displayOptions: ['showLegend', 'showGrid', 'showTooltip', 'showAllXLabels', 'hideHeader'],
   displayOptionsConfig: [
-    {
-      key: 'connectNulls',
-      label: 'chart.option.connectNulls.label',
-      type: 'boolean',
-      defaultValue: false,
-      description: 'chart.option.connectNulls.description'
-    },
-    {
-      key: 'target',
-      label: 'chart.option.target.label',
-      type: 'string',
-      placeholder: 'e.g., 100 or 50,75 for spread',
-      description: 'chart.option.target.description'
-    },
+    connectNullsDisplayOption,
+    targetDisplayOption,
     {
       key: 'priorPeriodStyle',
       label: 'chart.option.priorPeriodStyle.label',
@@ -78,17 +69,7 @@ export const lineChartConfig: ChartTypeConfig = {
       step: 0.1,
       description: 'chart.option.priorPeriodOpacity.description'
     },
-    {
-      key: 'leftYAxisFormat',
-      label: 'chart.option.leftYAxisFormat.label',
-      type: 'axisFormat',
-      description: 'chart.option.leftYAxisFormat.description'
-    },
-    {
-      key: 'rightYAxisFormat',
-      label: 'chart.option.rightYAxisFormat.label',
-      type: 'axisFormat',
-      description: 'chart.option.rightYAxisFormat.description'
-    }
+    leftYAxisFormatDisplayOption,
+    rightYAxisFormatDisplayOption
   ]
 }

--- a/src/client/components/charts/LineChart.tsx
+++ b/src/client/components/charts/LineChart.tsx
@@ -1,12 +1,22 @@
 import React, { useState, useMemo } from 'react'
 import { useTranslation } from '../../hooks/useTranslation'
-import { LineChart as RechartsLineChart, Line, XAxis, YAxis, CartesianGrid, Legend } from 'recharts'
+import { LineChart as RechartsLineChart, Line, XAxis, CartesianGrid } from 'recharts'
 import ChartContainer from './ChartContainer'
 import ChartTooltip from './ChartTooltip'
 import AngledXAxisTick from './AngledXAxisTick'
-import { CHART_COLORS, CHART_MARGINS } from '../../utils/chartConstants'
-import { transformChartDataWithSeries, formatAxisValue, formatTimeValue, getFieldGranularity } from '../../utils/chartUtils'
-import { parseTargetValues, spreadTargetValues } from '../../utils/targetUtils'
+import { ChartEmptyState, ChartConfigError, ChartRenderError } from './ChartStates'
+import { resolveChartAxisFields } from './chartAxisResolution'
+import {
+  getDualAxisInfo,
+  getYAxisChartMargins,
+  withTargetData,
+  renderDualYAxes,
+  renderChartTargetLines,
+  makeCartesianTooltipFormatter,
+  renderHoverLegend
+} from './chartScaffolding'
+import { CHART_COLORS } from '../../utils/chartConstants'
+import { transformChartDataWithSeries, formatTimeValue, getFieldGranularity } from '../../utils/chartUtils'
 import {
   isComparisonData,
   getPeriodLabels,
@@ -32,17 +42,13 @@ const LineChart = React.memo(function LineChart({
   // Use specialized hook to avoid re-renders from unrelated context changes
   const getFieldLabel = useCubeFieldLabel()
 
-  // Extract Y-axis fields early for use in useMemo hooks
-  // This ensures hooks are always called in the same order
-  const yAxisFields = useMemo(() => {
-    if (chartConfig?.yAxis) {
-      return Array.isArray(chartConfig.yAxis) ? chartConfig.yAxis : [chartConfig.yAxis]
-    }
-    if (chartConfig?.y) {
-      return Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y]
-    }
-    return []
-  }, [chartConfig?.yAxis, chartConfig?.y])
+  // Resolve + validate axis fields (hooks-first to satisfy React rules).
+  // xAxisField is aliased; it is narrowed to a definite string after the
+  // errorCode guard inside the render body below.
+  const { xAxisField: resolvedXAxisField, yAxisFields, seriesFields, errorCode } = useMemo(
+    () => resolveChartAxisFields(chartConfig),
+    [chartConfig]
+  )
 
   // Dual Y-axis support: extract yAxisAssignment from chartConfig (memoized to prevent object recreation)
   // MUST be called before any early returns to satisfy React hooks rules
@@ -78,48 +84,15 @@ const LineChart = React.memo(function LineChart({
     const rightYAxisFormat = displayConfig?.rightYAxisFormat
 
     if (!data || data.length === 0) {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-text-muted" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.noData')}</div>
-            <div className="dc:text-xs text-dc-text-secondary">{t('chart.runtime.noDataHint.line')}</div>
-          </div>
-        </div>
-      )
+      return <ChartEmptyState height={height} hint={t('chart.runtime.noDataHint.line')} />
     }
 
-    // Validate chartConfig - support both legacy and new formats
-    let xAxisField: string
-    let seriesFields: string[] = []
-
-    if (chartConfig?.xAxis && chartConfig?.yAxis) {
-      // New format
-      xAxisField = Array.isArray(chartConfig.xAxis) ? chartConfig.xAxis[0] : chartConfig.xAxis
-      seriesFields = chartConfig.series || []
-    } else if (chartConfig?.x && chartConfig?.y) {
-      // Legacy format
-      xAxisField = chartConfig.x
-    } else {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-warning" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.configError')}</div>
-            <div className="dc:text-xs">{t('chart.runtime.configErrorHint.axisInvalid')}</div>
-          </div>
-        </div>
-      )
+    if (errorCode) {
+      return <ChartConfigError height={height} hint={t(`chart.runtime.configErrorHint.${errorCode}`)} />
     }
 
-    if (!xAxisField || yAxisFields.length === 0) {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-warning" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.configError')}</div>
-            <div className="dc:text-xs">{t('chart.runtime.configErrorHint.axisFields')}</div>
-          </div>
-        </div>
-      )
-    }
+    // The errorCode guard above guarantees xAxisField is defined here
+    const xAxisField = resolvedXAxisField as string
 
     // Check if this is comparison data (has __periodIndex metadata)
     const hasComparisonData = isComparisonData(data)
@@ -172,45 +145,27 @@ const LineChart = React.memo(function LineChart({
       return seriesKeyToField[measureLabel]
     }
 
-    // Determine if we need a right Y-axis
-    const hasRightAxis = yAxisFields.some((field) => yAxisAssignment[field] === 'right')
-
-    // Get fields for left and right axes for labels
-    const leftAxisFields = yAxisFields.filter((f) => (yAxisAssignment[f] || 'left') === 'left')
-    const rightAxisFields = yAxisFields.filter((f) => yAxisAssignment[f] === 'right')
+    // Dual Y-axis derivation + margins (shared scaffolding)
+    const axisInfo = getDualAxisInfo(yAxisFields, yAxisAssignment)
+    const { hasRightAxis } = axisInfo
 
     // Determine if legend will be shown
     const showLegend = safeDisplayConfig.showLegend
 
     // Use custom chart margins with extra space for Y-axis labels
-    const chartMargins = {
-      ...CHART_MARGINS,
-      left: 40, // Space for left Y-axis label
-      right: hasRightAxis ? 40 : 20 // Extra space for right Y-axis label if needed
-    }
+    const chartMargins = getYAxisChartMargins(hasRightAxis)
 
     // Process target values and add to chart data
-    const targetValues = parseTargetValues(displayConfig?.target || '')
-    const spreadTargets = spreadTargetValues(targetValues, chartData.length)
-
-    // Add target data to chart data if targets exist
-    let enhancedChartData = chartData
-    if (spreadTargets.length > 0) {
-      enhancedChartData = chartData.map((dataPoint, index) => ({
-        ...dataPoint,
-        __target: spreadTargets[index] || null
-      }))
-    }
+    const { spreadTargets, enhancedChartData } = withTargetData(chartData, displayConfig?.target)
 
     // Validate transformed data
     if (!chartData || chartData.length === 0) {
       return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-text-muted" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.noValidData')}</div>
-            <div className="dc:text-xs text-dc-text-secondary">No valid data points for line chart after transformation</div>
-          </div>
-        </div>
+        <ChartEmptyState
+          height={height}
+          titleKey="chart.runtime.noValidData"
+          hint="No valid data points for line chart after transformation"
+        />
       )
     }
 
@@ -240,59 +195,15 @@ const LineChart = React.memo(function LineChart({
             height={60}
             interval={showAllXLabels ? 0 : undefined}
           />
-          <YAxis
-            yAxisId="left"
-            orientation="left"
-            tick={{ fontSize: 12 }}
-            tickFormatter={leftYAxisFormat ? (value) => formatAxisValue(value, leftYAxisFormat) : undefined}
-            label={
-              leftAxisFields.length > 0
-                ? {
-                    value: leftYAxisFormat?.label || getFieldLabel(leftAxisFields[0]),
-                    angle: -90,
-                    position: 'left',
-                    style: { textAnchor: 'middle', fontSize: '12px' }
-                  }
-                : undefined
-            }
-          />
-          {hasRightAxis && (
-            <YAxis
-              yAxisId="right"
-              orientation="right"
-              tick={{ fontSize: 12 }}
-              tickFormatter={rightYAxisFormat ? (value) => formatAxisValue(value, rightYAxisFormat) : undefined}
-              label={
-                rightAxisFields.length > 0
-                  ? {
-                      value: rightYAxisFormat?.label || getFieldLabel(rightAxisFields[0]),
-                      angle: 90,
-                      position: 'right',
-                      style: { textAnchor: 'middle', fontSize: '12px' }
-                    }
-                  : undefined
-              }
-            />
-          )}
+          {renderDualYAxes(axisInfo, getFieldLabel, leftYAxisFormat, rightYAxisFormat)}
           {safeDisplayConfig.showTooltip && (
             <ChartTooltip
-              formatter={(value: any, name: any) => {
-                // Handle null values in tooltip
-                if (value === null || value === undefined) {
-                  return ['No data', name]
-                }
-                if (name === 'Target') {
-                  // Use left Y-axis format for target values
-                  return [formatAxisValue(value, leftYAxisFormat), 'Target Value']
-                }
-
-                // Determine which axis format to use based on series name
-                const originalField = findFieldFromSeriesKey(name)
-                const axisId = originalField && yAxisAssignment[originalField] === 'right' ? 'right' : 'left'
-                const formatConfig = axisId === 'right' ? rightYAxisFormat : leftYAxisFormat
-                // Series name is already formatted (e.g., "Total Lines of Code (Current)")
-                return [formatAxisValue(value, formatConfig), name]
-              }}
+              formatter={makeCartesianTooltipFormatter({
+                leftYAxisFormat,
+                rightYAxisFormat,
+                yAxisAssignment,
+                resolveField: findFieldFromSeriesKey
+              })}
               labelFormatter={
                 hasComparisonData
                   ? (label: any, payload: any) => {
@@ -311,18 +222,13 @@ const LineChart = React.memo(function LineChart({
               }
             />
           )}
-          {showLegend && (
-            <Legend
-              wrapperStyle={{ fontSize: '12px', paddingTop: '25px' }}
-              iconType="line"
-              iconSize={8}
-              layout="horizontal"
-              align="center"
-              verticalAlign="bottom"
-              onMouseEnter={(o) => setHoveredLegend(String(o.dataKey || ''))}
-              onMouseLeave={() => setHoveredLegend(null)}
-            />
-          )}
+          {renderHoverLegend({
+            show: showLegend,
+            iconType: 'line',
+            paddingTop: 25,
+            onHover: setHoveredLegend,
+            onLeave: () => setHoveredLegend(null)
+          })}
           {seriesKeys.map((seriesKey, index) => {
             // Look up the original field name to get its axis assignment
             const originalField = findFieldFromSeriesKey(seriesKey)
@@ -414,48 +320,12 @@ const LineChart = React.memo(function LineChart({
               />
             )
           })}
-          {spreadTargets.length > 0 && (
-            <>
-              {/* White background line */}
-              <Line
-                type="monotone"
-                dataKey="__target"
-                yAxisId="left"
-                stroke="#ffffff"
-                strokeWidth={2}
-                dot={false}
-                activeDot={false}
-                connectNulls={false}
-              />
-              {/* Grey dashed line on top */}
-              <Line
-                type="monotone"
-                dataKey="__target"
-                yAxisId="left"
-                name="Target"
-                stroke="#8B5CF6"
-                strokeWidth={2}
-                strokeDasharray="2 3"
-                dot={false}
-                activeDot={false}
-                connectNulls={false}
-              />
-            </>
-          )}
+          {renderChartTargetLines(spreadTargets)}
         </RechartsLineChart>
       </ChartContainer>
     )
   } catch (error) {
-    // 'LineChart rendering error
-    return (
-      <div className="dc:flex dc:flex-col dc:items-center dc:justify-center dc:w-full text-dc-error dc:p-4" style={{ height }}>
-        <div className="dc:text-center">
-          <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.chartError', { chartType: 'Line Chart' })}</div>
-          <div className="dc:text-xs dc:mb-2">{error instanceof Error ? error.message : t('chart.runtime.unknownError')}</div>
-          <div className="dc:text-xs text-dc-text-muted">{t('chart.runtime.checkConfig')}</div>
-        </div>
-      </div>
-    )
+    return <ChartRenderError height={height} chartType="Line Chart" error={error} />
   }
 })
 

--- a/src/client/components/charts/PieChart.config.ts
+++ b/src/client/components/charts/PieChart.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasureAndDimension, valueFormatDisplayOption } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the pie chart type
@@ -8,11 +9,7 @@ export const pieChartConfig: ChartTypeConfig = {
   description: 'chart.pie.description',
   useCase: 'chart.pie.useCase',
   clickableElements: { slice: true },
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   dropZones: [
     {
       key: 'xAxis',
@@ -49,11 +46,6 @@ export const pieChartConfig: ChartTypeConfig = {
         { value: '80%', label: 'chart.configText.80_percent' },
       ]
     },
-    {
-      key: 'leftYAxisFormat',
-      label: 'chart.option.valueFormat.label',
-      type: 'axisFormat',
-      description: 'chart.option.valueFormat.description'
-    }
+    valueFormatDisplayOption()
   ]
 }

--- a/src/client/components/charts/PieChart.tsx
+++ b/src/client/components/charts/PieChart.tsx
@@ -1,12 +1,88 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import { useTranslation } from '../../hooks/useTranslation'
 import { PieChart as RechartsPieChart, Pie, Cell, Legend } from 'recharts'
 import ChartContainer from './ChartContainer'
 import ChartTooltip from './ChartTooltip'
+import { ChartEmptyState, ChartConfigError, ChartRenderError } from './ChartStates'
+import { resolveChartAxisFields } from './chartAxisResolution'
 import { CHART_COLORS } from '../../utils/chartConstants'
 import { transformChartDataWithSeries, formatTimeValue, getFieldGranularity, formatAxisValue } from '../../utils/chartUtils'
 import { useCubeFieldLabel } from '../../hooks/useCubeFieldLabel'
-import type { ChartProps } from '../../types'
+import type { ChartProps, CubeQuery } from '../../types'
+
+interface PieSlice {
+  name: string
+  value: number
+}
+
+/**
+ * Build pie slices from query data, supporting both series-based (dimension
+ * slices) and standard measure-based pies. Returns the slices that survive
+ * value filtering plus the pre-filter count (so the caller can explain how
+ * many points were dropped). Pure — extracted to keep `PieChart` simple.
+ */
+function buildPieData(
+  data: any[],
+  xField: string,
+  yAxisFields: string[],
+  seriesFields: string[],
+  queryObject: CubeQuery | undefined,
+  getFieldLabel: (field: string) => string
+): { pieData: PieSlice[]; originalLength: number } {
+  let pieData: PieSlice[]
+
+  if (seriesFields.length > 0) {
+    // Use series-based transformation for dimension-based pie slices
+    const { data: chartData } = transformChartDataWithSeries(
+      data,
+      xField,
+      yAxisFields,
+      queryObject,
+      seriesFields,
+      getFieldLabel
+    )
+
+    // Convert series data to pie format
+    pieData = []
+    if (chartData.length > 0) {
+      const firstRow = chartData[0]
+      Object.keys(firstRow).forEach(key => {
+        if (key !== 'name' && typeof firstRow[key] === 'number') {
+          pieData.push({ name: String(key), value: firstRow[key] })
+        }
+      })
+    }
+  } else {
+    // Standard measure-based pie chart
+    const granularity = getFieldGranularity(queryObject, xField)
+    pieData = data.map(item => {
+      let name = formatTimeValue(item[xField], granularity) || String(item[xField]) || 'Unknown'
+      // Handle boolean values with better labels
+      if (typeof item[xField] === 'boolean') {
+        name = item[xField] ? 'Active' : 'Inactive'
+      } else if (name === 'true' || name === 'false') {
+        name = name === 'true' ? 'Active' : 'Inactive'
+      }
+      return {
+        name,
+        value: typeof item[yAxisFields[0]] === 'string'
+          ? parseFloat(item[yAxisFields[0]])
+          : (item[yAxisFields[0]] || 0)
+      }
+    })
+  }
+
+  // Filter out invalid values (null, undefined, NaN, or non-positive)
+  const originalLength = pieData.length
+  pieData = pieData.filter(item =>
+    item.value != null &&
+    !isNaN(item.value) &&
+    item.value !== 0 &&
+    item.value > 0
+  )
+
+  return { pieData, originalLength }
+}
 
 const PieChart = React.memo(function PieChart({
   data,
@@ -22,7 +98,13 @@ const PieChart = React.memo(function PieChart({
   const [hoveredLegend, setHoveredLegend] = useState<string | null>(null)
   // Use specialized hook to avoid re-renders from unrelated context changes
   const getFieldLabel = useCubeFieldLabel()
-  
+
+  // Resolve + validate axis fields (hooks-first to satisfy React rules)
+  const { xAxisField, yAxisFields, seriesFields, errorCode } = useMemo(
+    () => resolveChartAxisFields(chartConfig),
+    [chartConfig]
+  )
+
   try {
     const safeDisplayConfig = {
       showLegend: displayConfig?.showLegend ?? true,
@@ -32,120 +114,40 @@ const PieChart = React.memo(function PieChart({
     }
 
     if (!data || data.length === 0) {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-text-muted" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.noData')}</div>
-            <div className="dc:text-xs text-dc-text-secondary">{t('chart.runtime.noDataHint.pie')}</div>
-          </div>
-        </div>
-      )
+      return <ChartEmptyState height={height} hint={t('chart.runtime.noDataHint.pie')} />
     }
 
-    let pieData: Array<{name: string, value: number}>
-
-    // Validate chartConfig - support both legacy and new formats
-    let xAxisField: string
-    let yAxisFields: string[]
-    let seriesFields: string[] = []
-    
-    if (chartConfig?.xAxis && chartConfig?.yAxis) {
-      // New format
-      xAxisField = Array.isArray(chartConfig.xAxis) ? chartConfig.xAxis[0] : chartConfig.xAxis
-      yAxisFields = Array.isArray(chartConfig.yAxis) ? chartConfig.yAxis : [chartConfig.yAxis]
-      seriesFields = chartConfig.series || []
-    } else if (chartConfig?.x && chartConfig?.y) {
-      // Legacy format
-      xAxisField = chartConfig.x
-      yAxisFields = Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y]
-    } else {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-warning" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.configError')}</div>
-            <div className="dc:text-xs">{t('chart.runtime.configErrorHint.pieAxis')}</div>
-          </div>
-        </div>
-      )
+    if (errorCode) {
+      // Pie surfaces a pie-specific message for the "invalid config" case
+      const hintKey = errorCode === 'axisInvalid'
+        ? 'chart.runtime.configErrorHint.pieAxis'
+        : 'chart.runtime.configErrorHint.axisFields'
+      return <ChartConfigError height={height} hint={t(hintKey)} />
     }
 
-    if (!xAxisField || !yAxisFields || yAxisFields.length === 0) {
-      return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-warning" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.configError')}</div>
-            <div className="dc:text-xs">{t('chart.runtime.configErrorHint.axisFields')}</div>
-          </div>
-        </div>
-      )
-    }
+    // The errorCode guard above guarantees xAxisField is defined here
+    const xField = xAxisField as string
 
-    if (seriesFields.length > 0) {
-      // Use series-based transformation for dimension-based pie slices
-      const { data: chartData } = transformChartDataWithSeries(
-        data,
-        xAxisField,
-        yAxisFields,
-        queryObject,
-        seriesFields,
-        getFieldLabel
-      )
-      
-      // Convert series data to pie format
-      pieData = []
-      if (chartData.length > 0) {
-        const firstRow = chartData[0]
-        Object.keys(firstRow).forEach(key => {
-          if (key !== 'name' && typeof firstRow[key] === 'number') {
-            pieData.push({
-              name: String(key),
-              value: firstRow[key]
-            })
-          }
-        })
-      }
-    } else {
-      // Standard measure-based pie chart
-      const granularity = getFieldGranularity(queryObject, xAxisField)
-      pieData = data.map(item => {
-        let name = formatTimeValue(item[xAxisField], granularity) || String(item[xAxisField]) || 'Unknown'
-        // Handle boolean values with better labels
-        if (typeof item[xAxisField] === 'boolean') {
-          name = item[xAxisField] ? 'Active' : 'Inactive'
-        } else if (name === 'true' || name === 'false') {
-          name = name === 'true' ? 'Active' : 'Inactive'
-        }
-        return {
-          name,
-          value: typeof item[yAxisFields[0]] === 'string' 
-            ? parseFloat(item[yAxisFields[0]]) 
-            : (item[yAxisFields[0]] || 0)
-        }
-      })
-    }
-
-    // Filter out invalid values (null, undefined, NaN, or zero)
-    const originalLength = pieData.length
-    pieData = pieData.filter(item => 
-      item.value != null && 
-      !isNaN(item.value) && 
-      item.value !== 0 && 
-      item.value > 0
+    const { pieData, originalLength } = buildPieData(
+      data,
+      xField,
+      yAxisFields,
+      seriesFields,
+      queryObject,
+      getFieldLabel
     )
-    
+
     if (pieData.length === 0) {
       return (
-        <div className="dc:flex dc:items-center dc:justify-center dc:w-full text-dc-text-muted" style={{ height }}>
-          <div className="dc:text-center">
-            <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.noValidData')}</div>
-            <div className="dc:text-xs text-dc-text-secondary">
-              {originalLength > 0
-                ? `Filtered out ${originalLength} data points (zero or invalid values)`
-                : 'No data points to display in pie chart'
-              }
-            </div>
-          </div>
-        </div>
+        <ChartEmptyState
+          height={height}
+          titleKey="chart.runtime.noValidData"
+          hint={
+            originalLength > 0
+              ? `Filtered out ${originalLength} data points (zero or invalid values)`
+              : 'No data points to display in pie chart'
+          }
+        />
       )
     }
   
@@ -207,16 +209,7 @@ const PieChart = React.memo(function PieChart({
       </ChartContainer>
     )
   } catch (error) {
-    // 'PieChart rendering error
-    return (
-      <div className="dc:flex dc:flex-col dc:items-center dc:justify-center dc:w-full text-dc-error dc:p-4" style={{ height }}>
-        <div className="dc:text-center">
-          <div className="dc:text-sm dc:font-semibold dc:mb-1">{t('chart.runtime.chartError', { chartType: 'Pie Chart' })}</div>
-          <div className="dc:text-xs dc:mb-2">{error instanceof Error ? error.message : t('chart.runtime.unknownError')}</div>
-          <div className="dc:text-xs text-dc-text-muted">{t('chart.runtime.checkConfig')}</div>
-        </div>
-      </div>
-    )
+    return <ChartRenderError height={height} chartType="Pie Chart" error={error} />
   }
 })
 

--- a/src/client/components/charts/RadarChart.config.ts
+++ b/src/client/components/charts/RadarChart.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasureAndDimension, valueFormatDisplayOption } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the radar chart type
@@ -7,11 +8,7 @@ export const radarChartConfig: ChartTypeConfig = {
   label: 'chart.radar.label',
   description: 'chart.radar.description',
   useCase: 'chart.radar.useCase',
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   dropZones: [
     {
       key: 'xAxis',
@@ -40,11 +37,6 @@ export const radarChartConfig: ChartTypeConfig = {
   ],
   displayOptions: ['showLegend', 'showGrid', 'showTooltip', 'hideHeader'],
   displayOptionsConfig: [
-    {
-      key: 'leftYAxisFormat',
-      label: 'chart.option.valueFormat.label',
-      type: 'axisFormat',
-      description: 'chart.option.valueFormat.description'
-    }
+    valueFormatDisplayOption()
   ]
 }

--- a/src/client/components/charts/RadialBarChart.config.ts
+++ b/src/client/components/charts/RadialBarChart.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasureAndDimension, valueFormatDisplayOption } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the radial bar chart type
@@ -7,11 +8,7 @@ export const radialBarChartConfig: ChartTypeConfig = {
   label: 'chart.radialBar.label',
   description: 'chart.radialBar.description',
   useCase: 'chart.radialBar.useCase',
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   dropZones: [
     {
       key: 'xAxis',
@@ -33,11 +30,6 @@ export const radialBarChartConfig: ChartTypeConfig = {
   ],
   displayOptions: ['showLegend', 'showTooltip', 'hideHeader'],
   displayOptionsConfig: [
-    {
-      key: 'leftYAxisFormat',
-      label: 'chart.option.valueFormat.label',
-      type: 'axisFormat',
-      description: 'chart.option.valueFormat.description'
-    }
+    valueFormatDisplayOption()
   ]
 }

--- a/src/client/components/charts/TreeMapChart.config.ts
+++ b/src/client/components/charts/TreeMapChart.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasureAndDimension, valueFormatDisplayOption } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the treemap chart type
@@ -7,11 +8,7 @@ export const treemapChartConfig: ChartTypeConfig = {
   label: 'chart.treemap.label',
   description: 'chart.treemap.description',
   useCase: 'chart.treemap.useCase',
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   dropZones: [
     {
       key: 'xAxis',
@@ -42,12 +39,7 @@ export const treemapChartConfig: ChartTypeConfig = {
   ],
   displayOptions: ['showLegend', 'showTooltip', 'hideHeader'],
   displayOptionsConfig: [
-    {
-      key: 'leftYAxisFormat',
-      label: 'chart.option.valueFormat.label',
-      type: 'axisFormat',
-      description: 'chart.configText.number_formatting_for_size_values'
-    }
+    valueFormatDisplayOption('chart.configText.number_formatting_for_size_values')
   ],
   clickableElements: { cell: true }
 }

--- a/src/client/components/charts/WaterfallChart.config.ts
+++ b/src/client/components/charts/WaterfallChart.config.ts
@@ -1,4 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs'
+import { requiresMeasureAndDimension } from '../../charts/chartConfigHelpers'
 
 /**
  * Configuration for the waterfall chart type
@@ -8,11 +9,7 @@ export const waterfallChartConfig: ChartTypeConfig = {
   description: 'chart.waterfall.description',
   useCase: 'chart.waterfall.useCase',
   clickableElements: { bar: true },
-  isAvailable: ({ measureCount, dimensionCount }) => {
-    if (measureCount < 1) return { available: false, reason: 'chart.availability.requiresMeasure' }
-    if (dimensionCount < 1) return { available: false, reason: 'chart.availability.requiresDimension' }
-    return { available: true }
-  },
+  isAvailable: requiresMeasureAndDimension,
   displayOptions: ['showTooltip', 'hideHeader'],
   dropZones: [
     {

--- a/src/client/components/charts/chartAxisResolution.ts
+++ b/src/client/components/charts/chartAxisResolution.ts
@@ -1,0 +1,59 @@
+import type { ChartAxisConfig } from '../../types'
+
+/**
+ * Discriminated error code returned by {@link resolveChartAxisFields} when the
+ * chart configuration is invalid. Each chart maps these codes to its own i18n
+ * hint key (e.g. pie charts surface a pie-specific message for `axisInvalid`).
+ */
+export type ChartAxisErrorCode = 'axisInvalid' | 'axisFields'
+
+/**
+ * Result of resolving X/Y/series fields from a {@link ChartAxisConfig}.
+ * When `errorCode` is non-null the field values are not usable and the chart
+ * should render a configuration-error state instead.
+ */
+export interface ResolvedChartAxisFields {
+  /** Resolved X-axis field (category), or undefined when the config is invalid */
+  xAxisField?: string
+  /** Resolved Y-axis (value/measure) fields */
+  yAxisFields: string[]
+  /** Optional series/grouping fields (only present in the new config format) */
+  seriesFields: string[]
+  /** Non-null when the configuration cannot produce a renderable axis setup */
+  errorCode: ChartAxisErrorCode | null
+}
+
+/**
+ * Pure resolver for the X/Y/series field extraction that Cartesian charts
+ * (bar, line, area, pie) all duplicated inline.
+ *
+ * Supports both the new format (`xAxis` / `yAxis` / `series` arrays) and the
+ * legacy format (`x` / `y`). Returns a discriminated `errorCode` rather than
+ * JSX so each chart can map it to its own i18n hint key and render its own
+ * guard component.
+ */
+export function resolveChartAxisFields(chartConfig?: ChartAxisConfig): ResolvedChartAxisFields {
+  let xAxisField: string | undefined
+  let yAxisFields: string[] = []
+  let seriesFields: string[] = []
+  let errorCode: ChartAxisErrorCode | null = null
+
+  if (chartConfig?.xAxis && chartConfig?.yAxis) {
+    // New format
+    xAxisField = Array.isArray(chartConfig.xAxis) ? chartConfig.xAxis[0] : chartConfig.xAxis
+    yAxisFields = Array.isArray(chartConfig.yAxis) ? chartConfig.yAxis : [chartConfig.yAxis]
+    seriesFields = chartConfig.series || []
+  } else if (chartConfig?.x && chartConfig?.y) {
+    // Legacy format
+    xAxisField = chartConfig.x
+    yAxisFields = Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y]
+  } else {
+    errorCode = 'axisInvalid'
+  }
+
+  if (!errorCode && (!xAxisField || yAxisFields.length === 0)) {
+    errorCode = 'axisFields'
+  }
+
+  return { xAxisField, yAxisFields, seriesFields, errorCode }
+}

--- a/src/client/components/charts/chartScaffolding.tsx
+++ b/src/client/components/charts/chartScaffolding.tsx
@@ -1,0 +1,235 @@
+import { Fragment } from 'react'
+import { YAxis, Line, Legend } from 'recharts'
+import { CHART_MARGINS } from '../../utils/chartConstants'
+import { formatAxisValue } from '../../utils/chartUtils'
+import { parseTargetValues, spreadTargetValues } from '../../utils/targetUtils'
+import type { AxisFormatConfig } from '../../types'
+
+/**
+ * Shared scaffolding for the Cartesian recharts charts (bar, line, area).
+ *
+ * These charts duplicated the same dual-Y-axis derivation, chart margins,
+ * target-line overlay, and the left/right `<YAxis>` JSX. The pure helpers and
+ * recharts render-helpers here own that shared setup. Render-helpers return
+ * recharts elements (inside a fragment) and are embedded directly in the chart
+ * children — recharts flattens fragments when discovering axes/series, exactly
+ * as it already does for the inline target-line fragment.
+ */
+
+export interface DualAxisInfo {
+  /** True when at least one measure is assigned to the right axis */
+  hasRightAxis: boolean
+  /** Measure fields rendered against the left axis */
+  leftAxisFields: string[]
+  /** Measure fields rendered against the right axis */
+  rightAxisFields: string[]
+}
+
+/** Derive left/right axis membership from per-measure axis assignments. */
+export function getDualAxisInfo(
+  yAxisFields: string[],
+  yAxisAssignment: Record<string, 'left' | 'right'>
+): DualAxisInfo {
+  const hasRightAxis = yAxisFields.some((field) => yAxisAssignment[field] === 'right')
+  const leftAxisFields = yAxisFields.filter((f) => (yAxisAssignment[f] || 'left') === 'left')
+  const rightAxisFields = yAxisFields.filter((f) => yAxisAssignment[f] === 'right')
+  return { hasRightAxis, leftAxisFields, rightAxisFields }
+}
+
+/** Chart margins with extra room for the Y-axis label(s). */
+export function getYAxisChartMargins(hasRightAxis: boolean) {
+  return {
+    ...CHART_MARGINS,
+    left: 40, // Space for left Y-axis label
+    right: hasRightAxis ? 40 : 20 // Extra space for right Y-axis label if needed
+  }
+}
+
+/**
+ * Apply target values (single or comma-separated spread) onto chart data,
+ * returning the spread targets plus data enhanced with a `__target` key.
+ */
+export function withTargetData<T extends Record<string, any>>(
+  chartData: T[],
+  target: string | undefined
+): { spreadTargets: number[]; enhancedChartData: T[] } {
+  const targetValues = parseTargetValues(target || '')
+  const spreadTargets = spreadTargetValues(targetValues, chartData.length)
+  const enhancedChartData = spreadTargets.length > 0
+    ? chartData.map((dataPoint, index) => ({ ...dataPoint, __target: spreadTargets[index] || null }))
+    : chartData
+  return { spreadTargets, enhancedChartData }
+}
+
+/**
+ * Render the left + optional right `<YAxis>`. Returns recharts elements in a
+ * fragment for embedding directly in the chart children. Positional args keep
+ * the (otherwise identical) call sites in each chart down to a single line.
+ *
+ * @param isPercentStack when true (area/bar percent stacking) the left axis shows 0–100%
+ */
+export function renderDualYAxes(
+  { hasRightAxis, leftAxisFields, rightAxisFields }: DualAxisInfo,
+  getFieldLabel: (field: string) => string,
+  leftYAxisFormat?: AxisFormatConfig,
+  rightYAxisFormat?: AxisFormatConfig,
+  isPercentStack = false
+) {
+  return (
+    <Fragment>
+      <YAxis
+        yAxisId="left"
+        orientation="left"
+        tick={{ fontSize: 12 }}
+        tickFormatter={
+          isPercentStack
+            ? (v) => `${(v * 100).toFixed(0)}%`
+            : leftYAxisFormat
+              ? (value) => formatAxisValue(value, leftYAxisFormat)
+              : undefined
+        }
+        domain={isPercentStack ? [0, 1] : undefined}
+        label={
+          isPercentStack
+            ? undefined
+            : leftAxisFields.length > 0
+              ? {
+                  value: leftYAxisFormat?.label || getFieldLabel(leftAxisFields[0]),
+                  angle: -90,
+                  position: 'left',
+                  style: { textAnchor: 'middle', fontSize: '12px' }
+                }
+              : undefined
+        }
+      />
+      {hasRightAxis && (
+        <YAxis
+          yAxisId="right"
+          orientation="right"
+          tick={{ fontSize: 12 }}
+          tickFormatter={rightYAxisFormat ? (value) => formatAxisValue(value, rightYAxisFormat) : undefined}
+          label={
+            rightAxisFields.length > 0
+              ? {
+                  value: rightYAxisFormat?.label || getFieldLabel(rightAxisFields[0]),
+                  angle: 90,
+                  position: 'right',
+                  style: { textAnchor: 'middle', fontSize: '12px' }
+                }
+              : undefined
+          }
+        />
+      )}
+    </Fragment>
+  )
+}
+
+/**
+ * Render the target overlay: a white backing line plus a purple dashed line
+ * on top (shared by bar, line, area). Returns null when there are no targets.
+ */
+export function renderChartTargetLines(spreadTargets: number[]) {
+  if (spreadTargets.length === 0) return null
+  return (
+    <Fragment>
+      {/* White background line */}
+      <Line
+        type="monotone"
+        dataKey="__target"
+        yAxisId="left"
+        stroke="#ffffff"
+        strokeWidth={2}
+        dot={false}
+        activeDot={false}
+        connectNulls={false}
+      />
+      {/* Grey dashed line on top */}
+      <Line
+        type="monotone"
+        dataKey="__target"
+        yAxisId="left"
+        name="Target"
+        stroke="#8B5CF6"
+        strokeWidth={2}
+        strokeDasharray="2 3"
+        dot={false}
+        activeDot={false}
+        connectNulls={false}
+      />
+    </Fragment>
+  )
+}
+
+interface CartesianTooltipOptions {
+  leftYAxisFormat?: AxisFormatConfig
+  rightYAxisFormat?: AxisFormatConfig
+  yAxisAssignment: Record<string, 'left' | 'right'>
+  /** Maps a series key (display label) back to its original measure field. */
+  resolveField: (name: string) => string | undefined
+  /** When true, values render as percentages (area/bar percent stacking). */
+  isPercentStack?: boolean
+}
+
+/**
+ * Build the value/name tooltip formatter shared by the Cartesian charts.
+ * Handles null values, the target series, percent stacking, and per-series
+ * left/right axis format selection.
+ */
+export function makeCartesianTooltipFormatter({
+  leftYAxisFormat,
+  rightYAxisFormat,
+  yAxisAssignment,
+  resolveField,
+  isPercentStack = false
+}: CartesianTooltipOptions) {
+  return (value: any, name: any): [any, any] => {
+    if (value === null || value === undefined) {
+      return ['No data', name]
+    }
+    if (name === 'Target') {
+      // Use left Y-axis format for target values
+      return [formatAxisValue(value, leftYAxisFormat), 'Target Value']
+    }
+    if (isPercentStack && typeof value === 'number') {
+      return [`${(value * 100).toFixed(1)}%`, name]
+    }
+    // Determine which axis format to use based on series name
+    const originalField = resolveField(name)
+    const axisId = originalField && yAxisAssignment[originalField] === 'right' ? 'right' : 'left'
+    const formatConfig = axisId === 'right' ? rightYAxisFormat : leftYAxisFormat
+    return [formatAxisValue(value, formatConfig), name]
+  }
+}
+
+/**
+ * Render the hover-aware bottom legend shared by the Cartesian charts.
+ * Returns null when the legend is hidden. `iconType` / `paddingTop` differ
+ * per chart (rect+10 for area, rect+25 for bar, line+25 for line).
+ */
+export function renderHoverLegend({
+  show,
+  iconType,
+  paddingTop,
+  onHover,
+  onLeave
+}: {
+  show: boolean
+  iconType: 'rect' | 'line' | 'circle'
+  paddingTop: number
+  onHover: (dataKey: string) => void
+  onLeave: () => void
+}) {
+  if (!show) return null
+  return (
+    <Legend
+      wrapperStyle={{ fontSize: '12px', paddingTop: `${paddingTop}px` }}
+      iconType={iconType}
+      iconSize={8}
+      layout="horizontal"
+      align="center"
+      verticalAlign="bottom"
+      onMouseEnter={(o) => onHover(String(o.dataKey || ''))}
+      onMouseLeave={onLeave}
+    />
+  )
+}

--- a/tests/client/components/charts/ChartStates.test.tsx
+++ b/tests/client/components/charts/ChartStates.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Tests for the shared chart guard-state components.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import {
+  ChartEmptyState,
+  ChartConfigError,
+  ChartRenderError
+} from '../../../../src/client/components/charts/ChartStates'
+
+describe('ChartStates', () => {
+  describe('ChartEmptyState', () => {
+    it('renders the default "No data available" title', () => {
+      render(<ChartEmptyState hint="No data points to display in bar chart" />)
+      expect(screen.getByText('No data available')).toBeInTheDocument()
+      expect(screen.getByText('No data points to display in bar chart')).toBeInTheDocument()
+    })
+
+    it('supports a custom title key for the post-transform state', () => {
+      render(<ChartEmptyState titleKey="chart.runtime.noValidData" hint="nothing left" />)
+      expect(screen.getByText('No valid data')).toBeInTheDocument()
+      expect(screen.getByText('nothing left')).toBeInTheDocument()
+    })
+
+    it('omits the hint when none is provided', () => {
+      const { container } = render(<ChartEmptyState />)
+      expect(screen.getByText('No data available')).toBeInTheDocument()
+      // Only the title div should be present, no secondary hint line
+      expect(container.querySelectorAll('div.dc\\:text-center > div').length).toBe(1)
+    })
+  })
+
+  describe('ChartConfigError', () => {
+    it('renders the "Configuration Error" title with a hint', () => {
+      render(<ChartConfigError hint="Invalid or missing chart axis configuration" />)
+      expect(screen.getByText('Configuration Error')).toBeInTheDocument()
+      expect(screen.getByText('Invalid or missing chart axis configuration')).toBeInTheDocument()
+    })
+  })
+
+  describe('ChartRenderError', () => {
+    it('renders a chart-type-specific heading and the error message', () => {
+      render(<ChartRenderError chartType="Bar Chart" error={new Error('boom')} />)
+      expect(screen.getByText('Bar Chart Error')).toBeInTheDocument()
+      expect(screen.getByText('boom')).toBeInTheDocument()
+      expect(screen.getByText('Check the data and configuration')).toBeInTheDocument()
+    })
+
+    it('falls back to a generic message for non-Error values', () => {
+      render(<ChartRenderError chartType="Pie Chart" error={'oops'} />)
+      expect(screen.getByText('Pie Chart Error')).toBeInTheDocument()
+      expect(screen.getByText('Unknown rendering error')).toBeInTheDocument()
+    })
+  })
+})

--- a/tests/client/components/charts/chartAxisResolution.test.ts
+++ b/tests/client/components/charts/chartAxisResolution.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for resolveChartAxisFields — the shared axis-field resolver used
+ * by the Cartesian charts (bar, line, area, pie).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { resolveChartAxisFields } from '../../../../src/client/components/charts/chartAxisResolution'
+
+describe('resolveChartAxisFields', () => {
+  describe('new format (xAxis / yAxis / series)', () => {
+    it('resolves array xAxis/yAxis with series', () => {
+      const result = resolveChartAxisFields({
+        xAxis: ['Orders.createdAt'],
+        yAxis: ['Sales.revenue', 'Sales.margin'],
+        series: ['Products.category']
+      })
+      expect(result).toEqual({
+        xAxisField: 'Orders.createdAt',
+        yAxisFields: ['Sales.revenue', 'Sales.margin'],
+        seriesFields: ['Products.category'],
+        errorCode: null
+      })
+    })
+
+    it('takes the first xAxis entry when multiple are provided', () => {
+      const result = resolveChartAxisFields({
+        xAxis: ['A', 'B'],
+        yAxis: ['Sales.revenue']
+      })
+      expect(result.xAxisField).toBe('A')
+      expect(result.errorCode).toBeNull()
+    })
+
+    it('handles non-array xAxis/yAxis (defensive)', () => {
+      const result = resolveChartAxisFields({
+        xAxis: 'Orders.createdAt' as unknown as string[],
+        yAxis: 'Sales.revenue' as unknown as string[]
+      })
+      expect(result.xAxisField).toBe('Orders.createdAt')
+      expect(result.yAxisFields).toEqual(['Sales.revenue'])
+      expect(result.errorCode).toBeNull()
+    })
+
+    it('defaults seriesFields to an empty array when absent', () => {
+      const result = resolveChartAxisFields({
+        xAxis: ['x'],
+        yAxis: ['y']
+      })
+      expect(result.seriesFields).toEqual([])
+    })
+  })
+
+  describe('legacy format (x / y)', () => {
+    it('resolves legacy x/y', () => {
+      const result = resolveChartAxisFields({
+        x: 'Orders.createdAt',
+        y: ['Sales.revenue']
+      })
+      expect(result).toEqual({
+        xAxisField: 'Orders.createdAt',
+        yAxisFields: ['Sales.revenue'],
+        seriesFields: [],
+        errorCode: null
+      })
+    })
+
+    it('wraps a non-array legacy y in an array', () => {
+      const result = resolveChartAxisFields({
+        x: 'Orders.createdAt',
+        y: 'Sales.revenue' as unknown as string[]
+      })
+      expect(result.yAxisFields).toEqual(['Sales.revenue'])
+      expect(result.errorCode).toBeNull()
+    })
+  })
+
+  describe('error cases', () => {
+    it('returns axisInvalid when config is undefined', () => {
+      expect(resolveChartAxisFields(undefined).errorCode).toBe('axisInvalid')
+    })
+
+    it('returns axisInvalid for an empty config', () => {
+      expect(resolveChartAxisFields({}).errorCode).toBe('axisInvalid')
+    })
+
+    it('returns axisInvalid when only yAxis is present', () => {
+      const result = resolveChartAxisFields({ yAxis: ['Sales.revenue'] })
+      expect(result.errorCode).toBe('axisInvalid')
+    })
+
+    it('returns axisInvalid when only xAxis is present', () => {
+      const result = resolveChartAxisFields({ xAxis: ['Orders.createdAt'] })
+      expect(result.errorCode).toBe('axisInvalid')
+    })
+
+    it('returns axisFields when yAxis is an empty array', () => {
+      const result = resolveChartAxisFields({ xAxis: ['Orders.createdAt'], yAxis: [] })
+      expect(result.errorCode).toBe('axisFields')
+    })
+
+    it('returns axisFields when xAxis is an empty array', () => {
+      const result = resolveChartAxisFields({ xAxis: [], yAxis: ['Sales.revenue'] })
+      expect(result.errorCode).toBe('axisFields')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #861.

## What & why

The chart components under `src/client/components/charts/` were the single largest source of duplication in the repo, and — per the issue — had **diverged in structure** (some used `try/catch` + inline early-returns, others `useMemo` + deferred `configError`), so a mechanical extraction was unsafe without first harmonising them. This PR does the harmonisation pass and then extracts the shared pieces.

## Changes

**1. Standardised control flow** (criterion #1) — Area, Bar, Line, Pie now all follow one hooks-first pattern: hooks → `useMemo(resolveChartAxisFields)` → transform `useMemo` → `try { …shared guards + render }`. `AreaChart` and `PieChart` were converted off their `try/catch` + inline-early-return style. Bare config-error strings in `BarChart` were replaced with i18n keys.

**2. Extracted + unit-tested shared helpers** (criterion #2):
- `chartAxisResolution.ts` — pure `resolveChartAxisFields()` returning a discriminated `errorCode` (`axisInvalid` / `axisFields`) that each chart maps to its own i18n hint key.
- `ChartStates.tsx` — shared `ChartEmptyState` / `ChartConfigError` / `ChartRenderError` guard components.
- `chartScaffolding.tsx` — `getDualAxisInfo`, `getYAxisChartMargins`, `withTargetData`, and recharts render-helpers `renderDualYAxes`, `renderChartTargetLines`, `makeCartesianTooltipFormatter`, `renderHoverLegend`.
- `chartConfigHelpers.ts` — config factory (`requiresMeasureAndDimension`, `requiresMeasure`, shared display-option builders).
- `PieChart` pie-data construction extracted into a pure `buildPieData()`.

**3. Deduped `*.config.ts` boilerplate** (criterion #3) across 13 chart configs via the factory.

## Duplication impact (`npx fallow dupes`, the issue's metric)

Chart-file duplication dropped materially:
- clone groups: **150 → 132 (−18)**
- duplicated lines: **~4661 → ~3608 (−23%)**

The largest clones (81-line and 47-line Area/Bar frames) collapsed. The residual structural similarity across the three sibling Cartesian charts (standardised preamble + frame) is intentional — fully collapsing them into a single parameterised component is a larger follow-up with real visual-regression risk, beyond this focused pass.

## Verification (criterion #4 — no visual regressions)

- `npm run typecheck` ✅ · `npm run lint` ✅
- `npm run test:client` — **5850/5850** (incl. 18 new unit tests for the resolver + guard components)
- `npm run test:e2e` chart screenshots — **18/18**
- Plus a throwaway real-browser smoke test confirming bar/line/area render dual-axis + targets + stacking with no error states.

## Also in this PR

Made the `quality` audit gate **report-only** (always exits 0; `fallow audit` still runs and prints its verdict) and updated the `quality-gate` skill doc to match — per a follow-up request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)