### PR TITLE
chore(deps): update react-grid-layout to v2.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12698,7 +12698,9 @@
       }
     },
     "node_modules/react-grid-layout": {
-      "version": "2.2.2",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.3.tgz",
+      "integrity": "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12706,7 +12708,7 @@
         "fast-equals": "^4.0.3",
         "prop-types": "^15.8.1",
         "react-draggable": "^4.4.6",
-        "react-resizable": "^3.0.5",
+        "react-resizable": "^3.1.3",
         "resize-observer-polyfill": "^1.5.1"
       },
       "peerDependencies": {

--- a/src/client/components/dashboard/DashboardContext.tsx
+++ b/src/client/components/dashboard/DashboardContext.tsx
@@ -147,8 +147,8 @@ export interface DashboardContextValue {
   handlePortletSave: (portletData: PortletConfig | Omit<PortletConfig, 'id' | 'x' | 'y'>) => Promise<void>
   handlePortletRefresh: (portletId: string, options?: { bustCache?: boolean }) => void
   handleLayoutChange: (layout: Layout) => void
-  handleDragStop: (layout: Layout, oldItem: LayoutItem | null, newItem: LayoutItem | null, placeholder: LayoutItem | null, e: Event, element: HTMLElement | undefined) => void
-  handleResizeStop: (layout: Layout, oldItem: LayoutItem | null, newItem: LayoutItem | null, placeholder: LayoutItem | null, e: Event, element: HTMLElement | undefined) => void
+  handleDragStop: (layout: Layout, oldItem: LayoutItem | null, newItem: LayoutItem | null, placeholder: LayoutItem | null, e: Event, element: HTMLElement | null) => void
+  handleResizeStop: (layout: Layout, oldItem: LayoutItem | null, newItem: LayoutItem | null, placeholder: LayoutItem | null, e: Event, element: HTMLElement | null) => void
   startRowResize: (rowIndex: number, event: MouseEvent<HTMLDivElement>) => void
   startColumnResize: (rowIndex: number, columnIndex: number, event: MouseEvent<HTMLDivElement>) => void
   handlePortletDragStart: (rowIndex: number, colIndex: number, portletId: string, event: DragEvent<HTMLDivElement>) => void

--- a/src/client/components/dashboard/DashboardCoordinator.tsx
+++ b/src/client/components/dashboard/DashboardCoordinator.tsx
@@ -269,7 +269,7 @@ export default function DashboardCoordinator({
   }, [])
 
   // Handle drag stop - save when user finishes dragging (only if layout actually changed)
-  const handleDragStop = useCallback(async (layout: Layout, _oldItem: LayoutItem | null, _newItem: LayoutItem | null, _placeholder: LayoutItem | null, _e: Event, _element: HTMLElement | undefined) => {
+  const handleDragStop = useCallback(async (layout: Layout, _oldItem: LayoutItem | null, _newItem: LayoutItem | null, _placeholder: LayoutItem | null, _e: Event, _element: HTMLElement | null) => {
     if (!editable || !isEditMode || !onSave || !isInitialized) return
 
     // Only save if the layout actually changed from user interaction
@@ -318,7 +318,7 @@ export default function DashboardCoordinator({
   }, [config, editable, isEditMode, onConfigChange, onSave, isInitialized, actions])
 
   // Handle resize stop - update config and save (resize is user interaction)
-  const handleResizeStop = useCallback(async (layout: Layout, _oldItem: LayoutItem | null, _newItem: LayoutItem | null, _placeholder: LayoutItem | null, _e: Event, _element: HTMLElement | undefined) => {
+  const handleResizeStop = useCallback(async (layout: Layout, _oldItem: LayoutItem | null, _newItem: LayoutItem | null, _placeholder: LayoutItem | null, _e: Event, _element: HTMLElement | null) => {
     if (!editable || !isEditMode || !onConfigChange || !isInitialized) return
 
     // Only proceed if the layout actually changed from user interaction


### PR DESCRIPTION
Updates `react-grid-layout` to **2.2.3**.

The stale Renovate PR #553 was based on v0.5.8 and could not merge cleanly. This redoes the upgrade on top of current `main`.

## Changes
- Bump `react-grid-layout` to 2.2.3 in the lockfile (within the existing `^2.1.1` range).
- The 2.2.x `EventCallback` type changed its `element` parameter from `HTMLElement | undefined` to `HTMLElement | null`. Widened the `onDragStop` / `onResizeStop` handlers in `DashboardCoordinator.tsx` and the matching `DashboardContext` types. Pure type change — no runtime behaviour change.

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)