### PR TITLE
Claude Code: Add quick text search box to the Data Browser filter panel

### DIFF
--- a/src/client/components/DataBrowser/DataBrowserToolbar.tsx
+++ b/src/client/components/DataBrowser/DataBrowserToolbar.tsx
@@ -12,6 +12,8 @@ const ColumnsIcon = getIcon('settings')
 const ChevronLeftIcon = getIcon('chevronLeft')
 const ChevronRightIcon = getIcon('chevronRight')
 const RefreshIcon = getIcon('refresh')
+const SearchIcon = getIcon('search')
+const CloseIcon = getIcon('close')
 
 interface DataBrowserToolbarProps {
   // Filter state
@@ -21,6 +23,10 @@ interface DataBrowserToolbarProps {
 
   // Column picker
   onToggleColumnPicker: () => void
+
+  // Quick text search
+  quickSearch: string
+  onQuickSearchChange: (value: string) => void
 
   // Pagination
   page: number
@@ -41,6 +47,8 @@ export default function DataBrowserToolbar({
   filterCount,
   onToggleFilterBar,
   onToggleColumnPicker,
+  quickSearch,
+  onQuickSearchChange,
   page,
   pageSize,
   rowCount,
@@ -80,6 +88,28 @@ export default function DataBrowserToolbar({
         <ColumnsIcon className="dc:w-3.5 dc:h-3.5" />
         {t('dataBrowser.toolbar.columns')}
       </button>
+
+      {/* Quick text search */}
+      <div className="dc:relative dc:flex-1 dc:max-w-xs">
+        <SearchIcon className="dc:absolute dc:left-2 dc:top-1/2 dc:-translate-y-1/2 dc:w-3.5 dc:h-3.5 text-dc-text-muted dc:pointer-events-none" />
+        <input
+          type="text"
+          value={quickSearch}
+          onChange={(e) => onQuickSearchChange(e.target.value)}
+          placeholder={t('dataBrowser.toolbar.searchPlaceholder')}
+          className="dc:w-full dc:pl-7 dc:pr-7 dc:py-1.5 dc:text-xs dc:rounded dc:border border-dc-border bg-dc-surface text-dc-text dc:outline-none dc:focus:ring-1 focus:ring-dc-accent"
+        />
+        {quickSearch && (
+          <button
+            onClick={() => onQuickSearchChange('')}
+            title={t('dataBrowser.toolbar.clearSearch')}
+            aria-label={t('dataBrowser.toolbar.clearSearch')}
+            className="dc:absolute dc:right-1.5 dc:top-1/2 dc:-translate-y-1/2 dc:p-0.5 dc:rounded dc:hover:bg-dc-surface-hover dc:transition-colors"
+          >
+            <CloseIcon className="dc:w-3.5 dc:h-3.5 text-dc-text-muted" />
+          </button>
+        )}
+      </div>
 
       {/* Spacer */}
       <div className="dc:flex-1" />

--- a/src/client/components/DataBrowser/index.tsx
+++ b/src/client/components/DataBrowser/index.tsx
@@ -46,6 +46,7 @@ function DataBrowserInner({ className = '', maxHeight = '100vh', loadingComponen
     page,
     pageSize,
     filters,
+    quickSearch,
     showFilterBar,
     showColumnPicker,
     rawData,
@@ -61,6 +62,7 @@ function DataBrowserInner({ className = '', maxHeight = '100vh', loadingComponen
     setPage,
     setPageSize,
     setFilters,
+    setQuickSearch,
     toggleFilterBar,
     setShowColumnPicker,
     toggleColumn,
@@ -135,6 +137,8 @@ function DataBrowserInner({ className = '', maxHeight = '100vh', loadingComponen
             filterCount={filterCount}
             onToggleFilterBar={toggleFilterBar}
             onToggleColumnPicker={() => setShowColumnPicker(!showColumnPicker)}
+            quickSearch={quickSearch}
+            onQuickSearchChange={setQuickSearch}
             page={page}
             pageSize={pageSize}
             rowCount={rowCount}

--- a/src/client/hooks/useDataBrowser.ts
+++ b/src/client/hooks/useDataBrowser.ts
@@ -11,7 +11,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useDataBrowserStore } from '../stores/dataBrowserStore.js'
 import { useCubeMeta } from '../providers/CubeProvider.js'
 import { useCubeLoadQuery } from './queries/useCubeLoadQuery.js'
-import type { CubeQuery } from '../types.js'
+import type { CubeQuery, GroupFilter } from '../types.js'
 
 /**
  * Determine whether a field is a dimension on a given cube from metadata
@@ -62,6 +62,26 @@ export function getCubeColumns(
   return { dimensions, measures }
 }
 
+/**
+ * Build an OR group of case-insensitive `contains` filters across all visible
+ * text (string) columns for the quick search box. Returns null when there's
+ * nothing to search (empty/whitespace term, or no text columns visible).
+ */
+export function buildQuickSearchFilter(
+  quickSearch: string,
+  visibleColumns: string[],
+  meta: Parameters<typeof getFieldType>[1]
+): GroupFilter | null {
+  const term = quickSearch.trim()
+  if (!term) return null
+  const textCols = visibleColumns.filter((c) => getFieldType(c, meta) === 'string')
+  if (textCols.length === 0) return null
+  return {
+    type: 'or',
+    filters: textCols.map((member) => ({ member, operator: 'contains', values: [term] })),
+  }
+}
+
 export function useDataBrowser() {
   // Store state
   const selectedCube = useDataBrowserStore((s) => s.selectedCube)
@@ -71,6 +91,7 @@ export function useDataBrowser() {
   const page = useDataBrowserStore((s) => s.page)
   const pageSize = useDataBrowserStore((s) => s.pageSize)
   const filters = useDataBrowserStore((s) => s.filters)
+  const quickSearch = useDataBrowserStore((s) => s.quickSearch)
   const showFilterBar = useDataBrowserStore((s) => s.showFilterBar)
   const showColumnPicker = useDataBrowserStore((s) => s.showColumnPicker)
 
@@ -85,6 +106,7 @@ export function useDataBrowser() {
       setPage: s.setPage,
       setPageSize: s.setPageSize,
       setFilters: s.setFilters,
+      setQuickSearch: s.setQuickSearch,
       toggleFilterBar: s.toggleFilterBar,
       setShowColumnPicker: s.setShowColumnPicker,
     }))
@@ -126,11 +148,15 @@ export function useDataBrowser() {
     }
 
     if (measures.length > 0) q.measures = measures
-    if (filters.length > 0) q.filters = filters
+
+    const quickGroup = buildQuickSearchFilter(quickSearch, visibleColumns, meta)
+    const allFilters = quickGroup ? [...filters, quickGroup] : filters
+    if (allFilters.length > 0) q.filters = allFilters
+
     if (effectiveSortColumn) q.order = { [effectiveSortColumn]: effectiveSortDirection }
 
     return q
-  }, [selectedCube, visibleColumns, filters, effectiveSortColumn, effectiveSortDirection, page, pageSize, meta])
+  }, [selectedCube, visibleColumns, filters, quickSearch, effectiveSortColumn, effectiveSortDirection, page, pageSize, meta])
 
   // Fetch data — keepPreviousData ON so pagination/sort keeps showing
   // stale data while new page loads. We detect cube switches by checking
@@ -177,6 +203,7 @@ export function useDataBrowser() {
     page,
     pageSize,
     filters,
+    quickSearch,
     showFilterBar,
     showColumnPicker,
 

--- a/src/client/stores/dataBrowserStore.tsx
+++ b/src/client/stores/dataBrowserStore.tsx
@@ -35,6 +35,9 @@ export interface DataBrowserStore {
   // Filters
   filters: Filter[]
 
+  // Quick text search (OR'd `contains` across visible text columns)
+  quickSearch: string
+
   // UI state
   showFilterBar: boolean
   showColumnPicker: boolean
@@ -51,6 +54,7 @@ export interface DataBrowserStore {
   setPage: (page: number) => void
   setPageSize: (size: number) => void
   setFilters: (filters: Filter[]) => void
+  setQuickSearch: (quickSearch: string) => void
   toggleFilterBar: () => void
   setShowColumnPicker: (show: boolean) => void
   setColumnWidth: (column: string, width: number) => void
@@ -101,6 +105,7 @@ function createDataBrowserStore(options: DataBrowserStoreOptions = {}) {
     page: 0,
     pageSize: options.defaultPageSize ?? 20,
     filters: [],
+    quickSearch: '',
     showFilterBar: false,
     showColumnPicker: false,
     columnWidths: options.defaultCube ? loadColumnWidths(options.defaultCube) : {},
@@ -114,6 +119,7 @@ function createDataBrowserStore(options: DataBrowserStoreOptions = {}) {
         sortDirection: 'asc',
         page: 0,
         filters: [],
+        quickSearch: '',
         showFilterBar: false,
         columnWidths: loadColumnWidths(cubeName),
       }),
@@ -155,6 +161,8 @@ function createDataBrowserStore(options: DataBrowserStoreOptions = {}) {
     setPageSize: (size) => set({ pageSize: size, page: 0 }),
 
     setFilters: (filters) => set({ filters, page: 0 }),
+
+    setQuickSearch: (quickSearch) => set({ quickSearch, page: 0 }),
 
     toggleFilterBar: () =>
       set((state) => ({ showFilterBar: !state.showFilterBar })),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -951,6 +951,8 @@
   "dataBrowser.noRows": "No rows returned for this query",
   "dataBrowser.toolbar.filters": "Filters",
   "dataBrowser.toolbar.columns": "Columns",
+  "dataBrowser.toolbar.searchPlaceholder": "Search rows…",
+  "dataBrowser.toolbar.clearSearch": "Clear search",
   "dataBrowser.toolbar.rows": "{count} rows",
   "dataBrowser.sidebar.cubes": "Cubes",
   "dataBrowser.sidebar.searchPlaceholder": "Search...",

--- a/src/i18n/locales/nl-NL.json
+++ b/src/i18n/locales/nl-NL.json
@@ -911,6 +911,8 @@
   "dataBrowser.noRows": "Geen rijen geretourneerd voor deze query",
   "dataBrowser.toolbar.filters": "Filters",
   "dataBrowser.toolbar.columns": "Kolommen",
+  "dataBrowser.toolbar.searchPlaceholder": "Rijen zoeken…",
+  "dataBrowser.toolbar.clearSearch": "Zoekopdracht wissen",
   "dataBrowser.toolbar.rows": "{count} rijen",
   "dataBrowser.sidebar.cubes": "Kubussen",
   "dataBrowser.sidebar.searchPlaceholder": "Zoeken...",

--- a/tests/client/buildQuickSearchFilter.test.ts
+++ b/tests/client/buildQuickSearchFilter.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for buildQuickSearchFilter
+ *
+ * The Data Browser quick search box turns a free-text term into an OR group of
+ * case-insensitive `contains` filters across the visible text (string) columns.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildQuickSearchFilter } from '../../src/client/hooks/useDataBrowser'
+
+// Minimal metadata shape accepted by getFieldType: cubes with typed dimensions/measures
+const meta = {
+  cubes: [
+    {
+      name: 'Orders',
+      dimensions: [
+        { name: 'Orders.status', type: 'string' },
+        { name: 'Orders.customer', type: 'string' },
+        { name: 'Orders.createdAt', type: 'time' },
+      ],
+      measures: [
+        { name: 'Orders.amount', type: 'number' },
+      ],
+    },
+  ],
+}
+
+describe('buildQuickSearchFilter', () => {
+  it('returns null for an empty or whitespace-only term', () => {
+    expect(buildQuickSearchFilter('', ['Orders.status'], meta)).toBeNull()
+    expect(buildQuickSearchFilter('   ', ['Orders.status'], meta)).toBeNull()
+  })
+
+  it('returns null when no visible columns are text', () => {
+    expect(buildQuickSearchFilter('acme', ['Orders.createdAt', 'Orders.amount'], meta)).toBeNull()
+  })
+
+  it('builds an OR group of contains filters over text columns only', () => {
+    const result = buildQuickSearchFilter(
+      'acme',
+      ['Orders.status', 'Orders.customer', 'Orders.createdAt', 'Orders.amount'],
+      meta
+    )
+    expect(result).toEqual({
+      type: 'or',
+      filters: [
+        { member: 'Orders.status', operator: 'contains', values: ['acme'] },
+        { member: 'Orders.customer', operator: 'contains', values: ['acme'] },
+      ],
+    })
+  })
+
+  it('trims the search term before building filters', () => {
+    const result = buildQuickSearchFilter('  acme  ', ['Orders.status'], meta)
+    expect(result).toEqual({
+      type: 'or',
+      filters: [{ member: 'Orders.status', operator: 'contains', values: ['acme'] }],
+    })
+  })
+})


### PR DESCRIPTION
## What

Adds an always-visible quick search box to the Data Browser toolbar. Typing a term narrows the table to rows where **any visible text column contains** it — case-insensitive, OR'd across columns — with a ✕ button to clear and return to the full result set.

Closes #885.

## How it works

- **Server-side filter.** The Data Browser is server-side and paginated, so filtering loaded rows client-side would only touch the current page. Instead the search generates a `{ type: 'or', filters: [...] }` group of `contains` filters over the `'string'`-typed visible columns and AND's it into the existing query filters. This filters the full result set correctly.
- **No server changes.** The `contains` operator is already case-insensitive on all 7 engines (`base-adapter.ts` → `caseInsensitiveLike`).
- **Independent of the structured filter panel.** Quick search lives in its own `quickSearch` store field (not the `filters` array), so it never clutters the filter UI or the filter-count badge.
- **Scope:** only the text columns currently visible in the table, so it tracks what the user sees.

## Decisions

- Placed in the **toolbar** (always visible) rather than the collapsed filter panel, for discoverability / genuine "quick" access.
- Searches **visible text columns** only.

## Files changed

- `stores/dataBrowserStore.tsx` — `quickSearch` state + `setQuickSearch` action (resets to page 0; cleared on cube switch)
- `hooks/useDataBrowser.ts` — exported `buildQuickSearchFilter()` helper + query merge
- `components/DataBrowser/DataBrowserToolbar.tsx` — search input with search/clear icons
- `components/DataBrowser/index.tsx` — props wired through
- `i18n/locales/en.json`, `nl-NL.json` — two new `dataBrowser.toolbar.*` keys
- `tests/client/buildQuickSearchFilter.test.ts` — unit tests for the filter builder

## Edge cases

- No visible text columns or whitespace-only input → harmless no-op (no filter added)
- Combines with structured filters (AND'd)
- Pagination resets to page 0 and filters the full server result set

## Verification

- New unit test passes (4/4); changed files typecheck + lint clean; i18n key-parity test passes (29/29)
- Manual: pick a cube, type a term → rows narrow (case-insensitive); numeric/date columns ignored; ✕ clears; works alongside structured filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)