### PR TITLE
[Claude Code Version]: Add a search box to the data browser

### DIFF
--- a/src/client/components/DataBrowser/DataBrowserSearch.tsx
+++ b/src/client/components/DataBrowser/DataBrowserSearch.tsx
@@ -1,0 +1,48 @@
+/**
+ * DataBrowserSearch Component
+ *
+ * A quick, clearable text-search box for the DataBrowser. The typed term is
+ * matched (case-insensitive "contains") against every text column of the cube,
+ * OR'd together — a row stays visible if the term appears in any text field.
+ *
+ * Mirrors the sidebar search input pattern. The actual filter is built in
+ * useDataBrowser; this component is purely the controlled input.
+ */
+
+import { getIcon } from '../../icons/index.js'
+import { useTranslation } from '../../hooks/useTranslation.js'
+
+const SearchIcon = getIcon('search')
+const CloseIcon = getIcon('close')
+
+export interface DataBrowserSearchProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+export default function DataBrowserSearch({ value, onChange }: DataBrowserSearchProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="dc:relative">
+      <SearchIcon className="dc:absolute dc:left-2 dc:top-1/2 dc:-translate-y-1/2 dc:w-3.5 dc:h-3.5 text-dc-text-muted" />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={t('dataBrowser.search.placeholder')}
+        className="dc:w-full dc:pl-7 dc:pr-7 dc:py-1.5 dc:text-xs dc:rounded border-dc-border dc:border bg-dc-surface text-dc-text dc:outline-none dc:focus:ring-1 focus:ring-dc-accent"
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          aria-label={t('dataBrowser.search.clear')}
+          className="dc:absolute dc:right-2 dc:top-1/2 dc:-translate-y-1/2 dc:p-0.5 dc:rounded text-dc-text-muted dc:hover:bg-dc-surface-hover dc:hover:text-dc-text"
+        >
+          <CloseIcon className="dc:w-3.5 dc:h-3.5" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/client/components/DataBrowser/index.tsx
+++ b/src/client/components/DataBrowser/index.tsx
@@ -17,6 +17,7 @@ import { useDataBrowser, getCubeColumns } from '../../hooks/useDataBrowser.js'
 import DataBrowserSidebar from './DataBrowserSidebar.js'
 import DataBrowserToolbar from './DataBrowserToolbar.js'
 import DataBrowserTable from './DataBrowserTable.js'
+import DataBrowserSearch from './DataBrowserSearch.js'
 import AnalysisFilterSection from '../AnalysisBuilder/AnalysisFilterSection.js'
 import FieldSearchModal from '../AnalysisBuilder/FieldSearchModal.js'
 import type { MetaResponse, MetaField } from '../../shared/types.js'
@@ -46,6 +47,7 @@ function DataBrowserInner({ className = '', maxHeight = '100vh', loadingComponen
     page,
     pageSize,
     filters,
+    searchText,
     showFilterBar,
     showColumnPicker,
     rawData,
@@ -61,6 +63,7 @@ function DataBrowserInner({ className = '', maxHeight = '100vh', loadingComponen
     setPage,
     setPageSize,
     setFilters,
+    setSearchText,
     toggleFilterBar,
     setShowColumnPicker,
     toggleColumn,
@@ -145,6 +148,13 @@ function DataBrowserInner({ className = '', maxHeight = '100vh', loadingComponen
             isFetching={isFetching}
             onRefresh={() => refetch()}
           />
+        )}
+
+        {/* Quick search (always visible) */}
+        {selectedCube && (
+          <div className="dc:px-3 dc:py-2 dc:border-b border-dc-border bg-dc-surface">
+            <DataBrowserSearch value={searchText} onChange={setSearchText} />
+          </div>
         )}
 
         {/* Filter bar (collapsible) */}

--- a/src/client/hooks/useDataBrowser.ts
+++ b/src/client/hooks/useDataBrowser.ts
@@ -11,7 +11,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useDataBrowserStore } from '../stores/dataBrowserStore.js'
 import { useCubeMeta } from '../providers/CubeProvider.js'
 import { useCubeLoadQuery } from './queries/useCubeLoadQuery.js'
-import type { CubeQuery } from '../types.js'
+import type { CubeQuery, Filter } from '../types.js'
 
 /**
  * Determine whether a field is a dimension on a given cube from metadata
@@ -71,6 +71,7 @@ export function useDataBrowser() {
   const page = useDataBrowserStore((s) => s.page)
   const pageSize = useDataBrowserStore((s) => s.pageSize)
   const filters = useDataBrowserStore((s) => s.filters)
+  const searchText = useDataBrowserStore((s) => s.searchText)
   const showFilterBar = useDataBrowserStore((s) => s.showFilterBar)
   const showColumnPicker = useDataBrowserStore((s) => s.showColumnPicker)
 
@@ -85,6 +86,7 @@ export function useDataBrowser() {
       setPage: s.setPage,
       setPageSize: s.setPageSize,
       setFilters: s.setFilters,
+      setSearchText: s.setSearchText,
       toggleFilterBar: s.toggleFilterBar,
       setShowColumnPicker: s.setShowColumnPicker,
     }))
@@ -126,11 +128,23 @@ export function useDataBrowser() {
     }
 
     if (measures.length > 0) q.measures = measures
-    if (filters.length > 0) q.filters = filters
+
+    // Quick text search: OR a case-insensitive 'contains' across every text
+    // (string-type) dimension of the cube, AND-combined with structured filters.
+    const term = searchText.trim()
+    const cube = meta?.cubes.find((c) => c.name === selectedCube)
+    const textDimensions = cube?.dimensions.filter((d) => d.type === 'string').map((d) => d.name) ?? []
+    const searchGroup: Filter | null =
+      term && textDimensions.length > 0
+        ? { type: 'or', filters: textDimensions.map((member) => ({ member, operator: 'contains', values: [term] })) }
+        : null
+    const combinedFilters = searchGroup ? [...filters, searchGroup] : filters
+    if (combinedFilters.length > 0) q.filters = combinedFilters
+
     if (effectiveSortColumn) q.order = { [effectiveSortColumn]: effectiveSortDirection }
 
     return q
-  }, [selectedCube, visibleColumns, filters, effectiveSortColumn, effectiveSortDirection, page, pageSize, meta])
+  }, [selectedCube, visibleColumns, filters, searchText, effectiveSortColumn, effectiveSortDirection, page, pageSize, meta])
 
   // Fetch data — keepPreviousData ON so pagination/sort keeps showing
   // stale data while new page loads. We detect cube switches by checking
@@ -177,6 +191,7 @@ export function useDataBrowser() {
     page,
     pageSize,
     filters,
+    searchText,
     showFilterBar,
     showColumnPicker,
 

--- a/src/client/stores/dataBrowserStore.tsx
+++ b/src/client/stores/dataBrowserStore.tsx
@@ -35,6 +35,9 @@ export interface DataBrowserStore {
   // Filters
   filters: Filter[]
 
+  // Quick text search (OR'd 'contains' across the cube's text dimensions)
+  searchText: string
+
   // UI state
   showFilterBar: boolean
   showColumnPicker: boolean
@@ -51,6 +54,7 @@ export interface DataBrowserStore {
   setPage: (page: number) => void
   setPageSize: (size: number) => void
   setFilters: (filters: Filter[]) => void
+  setSearchText: (text: string) => void
   toggleFilterBar: () => void
   setShowColumnPicker: (show: boolean) => void
   setColumnWidth: (column: string, width: number) => void
@@ -101,6 +105,7 @@ function createDataBrowserStore(options: DataBrowserStoreOptions = {}) {
     page: 0,
     pageSize: options.defaultPageSize ?? 20,
     filters: [],
+    searchText: '',
     showFilterBar: false,
     showColumnPicker: false,
     columnWidths: options.defaultCube ? loadColumnWidths(options.defaultCube) : {},
@@ -114,6 +119,7 @@ function createDataBrowserStore(options: DataBrowserStoreOptions = {}) {
         sortDirection: 'asc',
         page: 0,
         filters: [],
+        searchText: '',
         showFilterBar: false,
         columnWidths: loadColumnWidths(cubeName),
       }),
@@ -155,6 +161,8 @@ function createDataBrowserStore(options: DataBrowserStoreOptions = {}) {
     setPageSize: (size) => set({ pageSize: size, page: 0 }),
 
     setFilters: (filters) => set({ filters, page: 0 }),
+
+    setSearchText: (text) => set({ searchText: text, page: 0 }),
 
     toggleFilterBar: () =>
       set((state) => ({ showFilterBar: !state.showFilterBar })),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -955,6 +955,8 @@
   "dataBrowser.sidebar.cubes": "Cubes",
   "dataBrowser.sidebar.searchPlaceholder": "Search...",
   "dataBrowser.sidebar.noCubes": "No cubes found",
+  "dataBrowser.search.placeholder": "Search rows...",
+  "dataBrowser.search.clear": "Clear search",
 
   "queryAnalysis.summary": "Query Summary",
   "queryAnalysis.summary.type": "Type",

--- a/src/i18n/locales/nl-NL.json
+++ b/src/i18n/locales/nl-NL.json
@@ -915,6 +915,8 @@
   "dataBrowser.sidebar.cubes": "Kubussen",
   "dataBrowser.sidebar.searchPlaceholder": "Zoeken...",
   "dataBrowser.sidebar.noCubes": "Geen cubes gevonden",
+  "dataBrowser.search.placeholder": "Rijen zoeken...",
+  "dataBrowser.search.clear": "Zoekopdracht wissen",
   "queryAnalysis.summary": "Query Samenvatting",
   "queryAnalysis.summary.type": "Type",
   "queryAnalysis.summary.cubes": "Kubussen",

--- a/tests/client/components/DataBrowser/dataBrowserStore.test.ts
+++ b/tests/client/components/DataBrowser/dataBrowserStore.test.ts
@@ -55,6 +55,58 @@ describe('DataBrowserStore', () => {
       )
       expect(result.current).toEqual([])
     })
+
+    it('should have empty searchText', () => {
+      const { result } = renderHook(
+        () => useDataBrowserStore((s) => s.searchText),
+        { wrapper: createWrapper() }
+      )
+      expect(result.current).toBe('')
+    })
+  })
+
+  describe('setSearchText', () => {
+    it('should update searchText and reset page to 0', () => {
+      const { result } = renderHook(
+        () => ({
+          searchText: useDataBrowserStore((s) => s.searchText),
+          page: useDataBrowserStore((s) => s.page),
+          setPage: useDataBrowserStore((s) => s.setPage),
+          setSearchText: useDataBrowserStore((s) => s.setSearchText),
+        }),
+        { wrapper: createWrapper() }
+      )
+
+      act(() => result.current.setPage(4))
+      expect(result.current.page).toBe(4)
+
+      act(() => result.current.setSearchText('acme'))
+
+      expect(result.current.searchText).toBe('acme')
+      expect(result.current.page).toBe(0)
+    })
+
+    it('should clear searchText on cube switch', () => {
+      const { result } = renderHook(
+        () => ({
+          searchText: useDataBrowserStore((s) => s.searchText),
+          selectCube: useDataBrowserStore((s) => s.selectCube),
+          setSearchText: useDataBrowserStore((s) => s.setSearchText),
+        }),
+        { wrapper: createWrapper() }
+      )
+
+      act(() => {
+        result.current.selectCube('Employees', ['Employees.id'])
+        result.current.setSearchText('acme')
+      })
+      expect(result.current.searchText).toBe('acme')
+
+      act(() => {
+        result.current.selectCube('Departments', ['Departments.id'])
+      })
+      expect(result.current.searchText).toBe('')
+    })
   })
 
   describe('selectCube', () => {


### PR DESCRIPTION
## Summary

Implements the quick text-search box requested in #890. Adds an always-visible search box above the Data Browser table: type a term and the table filters to rows where **any text column of the cube** contains it — case-insensitive, OR'd across all string dimensions — with a clear (×) button to wipe it.

## Approach

Because the Data Browser fetches **server-side, paginated** data (`useCubeLoadQuery`), client-side filtering would only search the currently loaded page. So the search is implemented as a **server-side filter**: an OR group of `contains` filters across the cube's string dimensions, AND-combined with any existing structured filters. The typed term is sent as a parameter (not concatenated into SQL).

The `contains` operator is already case-insensitive on all 7 engines (`BaseDatabaseAdapter.buildStringCondition` → `caseInsensitiveLike`), so **no backend changes were required**, and the existing 400ms query debounce coalesces per-keystroke updates.

### Behaviour
- Matches across all text columns of the cube (every string-type dimension), even ones not currently shown.
- Case-insensitive "contains" (`acme` finds `Acme`, `ACME`).
- Non-text columns (numeric, date, boolean) are ignored.
- Searches the whole result set, not just the loaded page.
- Clear button resets to the full result set; search clears when switching cubes.

## Changes

| File | Change |
|------|--------|
| `src/client/stores/dataBrowserStore.tsx` | `searchText` state + `setSearchText` action (resets page); cleared on cube switch |
| `src/client/hooks/useDataBrowser.ts` | builds the OR-group `contains` filter over text dimensions; exposes `searchText`/`setSearchText` |
| `src/client/components/DataBrowser/DataBrowserSearch.tsx` | **new** clearable search input (mirrors the sidebar search pattern) |
| `src/client/components/DataBrowser/index.tsx` | renders the always-visible search row |
| `src/i18n/locales/en.json`, `nl-NL.json` | `dataBrowser.search.placeholder` + `dataBrowser.search.clear` keys |
| `tests/client/components/DataBrowser/dataBrowserStore.test.ts` | tests for page reset + clear-on-cube-switch |

No server-side changes. No new query/filter types — reuses `GroupFilter` and the existing `contains` operator.

## Testing
- `npm run typecheck` — clean
- ESLint on changed files — clean
- i18n key parity (`tests/i18n/locales.test.ts`) — passes
- Full client suite — **5861 tests pass**; DataBrowser store tests — 21 pass

> [!NOTE]
> Automated verification only so far — manual end-to-end testing in the running app has not been performed yet.

Closes #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)