### PR TITLE
fix: generate CJS declarations for require exports

### DIFF
--- a/.attw.json
+++ b/.attw.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://cdn.jsdelivr.net/npm/@arethetypeswrong/cli/.attw.schema.json",
   "profile": "node16",
-  "excludeEntrypoints": ["client/styles.css"],
-  "ignoreRules": ["cjs-resolves-to-esm", "false-esm"]
+  "excludeEntrypoints": [
+    "client/styles.css"
+  ],
+  "ignoreRules": [
+    "cjs-resolves-to-esm"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -14,14 +14,24 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.js",
-      "require": "./dist/server/index.cjs"
+      "import": {
+        "types": "./dist/server/index.d.ts",
+        "default": "./dist/server/index.js"
+      },
+      "require": {
+        "types": "./dist/server/index.d.cts",
+        "default": "./dist/server/index.cjs"
+      }
     },
     "./server": {
-      "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.js",
-      "require": "./dist/server/index.cjs"
+      "import": {
+        "types": "./dist/server/index.d.ts",
+        "default": "./dist/server/index.js"
+      },
+      "require": {
+        "types": "./dist/server/index.d.cts",
+        "default": "./dist/server/index.cjs"
+      }
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
@@ -57,39 +67,74 @@
     },
     "./client/styles.css": "./dist/client/styles.css",
     "./adapters/hono": {
-      "types": "./dist/adapters/hono/index.d.ts",
-      "import": "./dist/adapters/hono/index.js",
-      "require": "./dist/adapters/hono/index.cjs"
+      "import": {
+        "types": "./dist/adapters/hono/index.d.ts",
+        "default": "./dist/adapters/hono/index.js"
+      },
+      "require": {
+        "types": "./dist/adapters/hono/index.d.cts",
+        "default": "./dist/adapters/hono/index.cjs"
+      }
     },
     "./adapters/express": {
-      "types": "./dist/adapters/express/index.d.ts",
-      "import": "./dist/adapters/express/index.js",
-      "require": "./dist/adapters/express/index.cjs"
+      "import": {
+        "types": "./dist/adapters/express/index.d.ts",
+        "default": "./dist/adapters/express/index.js"
+      },
+      "require": {
+        "types": "./dist/adapters/express/index.d.cts",
+        "default": "./dist/adapters/express/index.cjs"
+      }
     },
     "./adapters/fastify": {
-      "types": "./dist/adapters/fastify/index.d.ts",
-      "import": "./dist/adapters/fastify/index.js",
-      "require": "./dist/adapters/fastify/index.cjs"
+      "import": {
+        "types": "./dist/adapters/fastify/index.d.ts",
+        "default": "./dist/adapters/fastify/index.js"
+      },
+      "require": {
+        "types": "./dist/adapters/fastify/index.d.cts",
+        "default": "./dist/adapters/fastify/index.cjs"
+      }
     },
     "./adapters/nextjs": {
-      "types": "./dist/adapters/nextjs/index.d.ts",
-      "import": "./dist/adapters/nextjs/index.js",
-      "require": "./dist/adapters/nextjs/index.cjs"
+      "import": {
+        "types": "./dist/adapters/nextjs/index.d.ts",
+        "default": "./dist/adapters/nextjs/index.js"
+      },
+      "require": {
+        "types": "./dist/adapters/nextjs/index.d.cts",
+        "default": "./dist/adapters/nextjs/index.cjs"
+      }
     },
     "./adapters/utils": {
-      "types": "./dist/adapters/utils.d.ts",
-      "import": "./dist/adapters/utils.js",
-      "require": "./dist/adapters/utils.cjs"
+      "import": {
+        "types": "./dist/adapters/utils.d.ts",
+        "default": "./dist/adapters/utils.js"
+      },
+      "require": {
+        "types": "./dist/adapters/utils.d.cts",
+        "default": "./dist/adapters/utils.cjs"
+      }
     },
     "./adapters/types": {
-      "types": "./dist/adapters/types.d.ts",
-      "import": "./dist/adapters/types.js",
-      "require": "./dist/adapters/types.cjs"
+      "import": {
+        "types": "./dist/adapters/types.d.ts",
+        "default": "./dist/adapters/types.js"
+      },
+      "require": {
+        "types": "./dist/adapters/types.d.cts",
+        "default": "./dist/adapters/types.cjs"
+      }
     },
     "./mcp": {
-      "types": "./dist/adapters/mcp-tools.d.ts",
-      "import": "./dist/adapters/mcp-tools.js",
-      "require": "./dist/adapters/mcp-tools.cjs"
+      "import": {
+        "types": "./dist/adapters/mcp-tools.d.ts",
+        "default": "./dist/adapters/mcp-tools.js"
+      },
+      "require": {
+        "types": "./dist/adapters/mcp-tools.d.cts",
+        "default": "./dist/adapters/mcp-tools.cjs"
+      }
     }
   },
   "files": [
@@ -105,7 +150,7 @@
     "dev:build-server": "vite build src/server --watch --mode development",
     "dev:build-client": "vite build src/client --watch --mode development",
     "dev:mcp-app": "vite build --config vite.config.mcp-app.ts --watch",
-    "build": "npm run build:server && npm run build:mcp-app && npm run build:client && npm run build:adapters && npm run build:cli",
+    "build": "npm run build:server && npm run build:mcp-app && npm run build:client && npm run build:adapters && npm run build:cli && npm run build:cjs-types",
     "build:mcp-app": "vite build --config vite.config.mcp-app.ts && tsx scripts/generate-mcp-app-html.ts",
     "build:server": "vite build --config vite.config.server.ts",
     "build:client": "vite build --config vite.config.client.ts",
@@ -165,7 +210,8 @@
     "i18n:pull": "source .env 2>/dev/null; crowdin download",
     "preview": "npm run build:client && npm run preview:build && concurrently \"npm run dev:server\" \"npm run preview:serve\"",
     "preview:build": "cd dev/client && vite build --config vite.config.preview.ts",
-    "preview:serve": "cd dev/client && vite preview --config vite.config.preview.ts"
+    "preview:serve": "cd dev/client && vite preview --config vite.config.preview.ts",
+    "build:cjs-types": "tsx scripts/generate-cjs-types.ts"
   },
   "keywords": [
     "drizzle-orm",

--- a/scripts/generate-cjs-types.ts
+++ b/scripts/generate-cjs-types.ts
@@ -1,0 +1,37 @@
+import { cpSync, existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { extname, join } from 'node:path'
+
+const distDir = 'dist'
+
+function walk(dir: string): string[] {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry)
+    const stat = statSync(path)
+    return stat.isDirectory() ? walk(path) : [path]
+  })
+}
+
+function toCjsDeclaration(source: string): string {
+  // .d.cts files are interpreted as CommonJS declarations. Relative imports
+  // ending in .js must point at sibling .d.cts declarations instead of ESM
+  // .d.ts files, otherwise Node16/NodeNext consumers hit TS1479.
+  return source.replace(/((?:from|import)\s*\(?\s*['"]\.\.?[^'"]*)\.js(['"])/g, '$1.cjs$2')
+}
+
+const declarations = walk(distDir).filter((path) => path.endsWith('.d.ts'))
+
+for (const declaration of declarations) {
+  const cjsDeclaration = declaration.replace(/\.d\.ts$/, '.d.cts')
+  const source = readFileSync(declaration, 'utf8')
+  writeFileSync(cjsDeclaration, toCjsDeclaration(source))
+}
+
+// Vite emits CJS runtime chunks with hashed .cjs names. Declarations can import
+// generated chunks only for types; CJS declaration files need matching .d.cts
+// siblings when TypeScript follows rewritten .cjs specifiers.
+for (const declaration of declarations) {
+  if (extname(declaration) === '.ts') continue
+}
+
+console.log(`Generated ${declarations.length} CommonJS declaration files`)


### PR DESCRIPTION
## Summary
- adds a post-build step that emits `.d.cts` declaration files for CommonJS `require()` consumers
- wires CJS-capable exports to `require.types` while keeping ESM declarations under `import.types`
- removes the `false-esm` suppression from the attw gate so CJS type masquerading is checked again

Closes #881.

## Validation
- `npm run build`
- `npm run check:exports`

`npm test` was also attempted, but the local environment has no PostgreSQL test database listening on `127.0.0.1:54333`, so Vitest global setup fails before test discovery with `ECONNREFUSED`.
