### PR TITLE
fix: ship correct CJS types for require() consumers via subdir convention (#881)

### DIFF
--- a/.attw.json
+++ b/.attw.json
@@ -2,5 +2,5 @@
   "$schema": "https://cdn.jsdelivr.net/npm/@arethetypeswrong/cli/.attw.schema.json",
   "profile": "node16",
   "excludeEntrypoints": ["client/styles.css"],
-  "ignoreRules": ["cjs-resolves-to-esm", "false-esm"]
+  "ignoreRules": ["cjs-resolves-to-esm"]
 }

--- a/package.json
+++ b/package.json
@@ -14,14 +14,24 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.js",
-      "require": "./dist/server/index.cjs"
+      "import": {
+        "types": "./dist/server/index.d.ts",
+        "default": "./dist/server/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/server/index.d.ts",
+        "default": "./dist/server/index.cjs"
+      }
     },
     "./server": {
-      "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.js",
-      "require": "./dist/server/index.cjs"
+      "import": {
+        "types": "./dist/server/index.d.ts",
+        "default": "./dist/server/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/server/index.d.ts",
+        "default": "./dist/server/index.cjs"
+      }
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
@@ -57,39 +67,74 @@
     },
     "./client/styles.css": "./dist/client/styles.css",
     "./adapters/hono": {
-      "types": "./dist/adapters/hono/index.d.ts",
-      "import": "./dist/adapters/hono/index.js",
-      "require": "./dist/adapters/hono/index.cjs"
+      "import": {
+        "types": "./dist/adapters/hono/index.d.ts",
+        "default": "./dist/adapters/hono/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/adapters/hono/index.d.ts",
+        "default": "./dist/adapters/hono/index.cjs"
+      }
     },
     "./adapters/express": {
-      "types": "./dist/adapters/express/index.d.ts",
-      "import": "./dist/adapters/express/index.js",
-      "require": "./dist/adapters/express/index.cjs"
+      "import": {
+        "types": "./dist/adapters/express/index.d.ts",
+        "default": "./dist/adapters/express/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/adapters/express/index.d.ts",
+        "default": "./dist/adapters/express/index.cjs"
+      }
     },
     "./adapters/fastify": {
-      "types": "./dist/adapters/fastify/index.d.ts",
-      "import": "./dist/adapters/fastify/index.js",
-      "require": "./dist/adapters/fastify/index.cjs"
+      "import": {
+        "types": "./dist/adapters/fastify/index.d.ts",
+        "default": "./dist/adapters/fastify/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/adapters/fastify/index.d.ts",
+        "default": "./dist/adapters/fastify/index.cjs"
+      }
     },
     "./adapters/nextjs": {
-      "types": "./dist/adapters/nextjs/index.d.ts",
-      "import": "./dist/adapters/nextjs/index.js",
-      "require": "./dist/adapters/nextjs/index.cjs"
+      "import": {
+        "types": "./dist/adapters/nextjs/index.d.ts",
+        "default": "./dist/adapters/nextjs/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/adapters/nextjs/index.d.ts",
+        "default": "./dist/adapters/nextjs/index.cjs"
+      }
     },
     "./adapters/utils": {
-      "types": "./dist/adapters/utils.d.ts",
-      "import": "./dist/adapters/utils.js",
-      "require": "./dist/adapters/utils.cjs"
+      "import": {
+        "types": "./dist/adapters/utils.d.ts",
+        "default": "./dist/adapters/utils.js"
+      },
+      "require": {
+        "types": "./dist/cjs/adapters/utils.d.ts",
+        "default": "./dist/adapters/utils.cjs"
+      }
     },
     "./adapters/types": {
-      "types": "./dist/adapters/types.d.ts",
-      "import": "./dist/adapters/types.js",
-      "require": "./dist/adapters/types.cjs"
+      "import": {
+        "types": "./dist/adapters/types.d.ts",
+        "default": "./dist/adapters/types.js"
+      },
+      "require": {
+        "types": "./dist/cjs/adapters/types.d.ts",
+        "default": "./dist/adapters/types.cjs"
+      }
     },
     "./mcp": {
-      "types": "./dist/adapters/mcp-tools.d.ts",
-      "import": "./dist/adapters/mcp-tools.js",
-      "require": "./dist/adapters/mcp-tools.cjs"
+      "import": {
+        "types": "./dist/adapters/mcp-tools.d.ts",
+        "default": "./dist/adapters/mcp-tools.js"
+      },
+      "require": {
+        "types": "./dist/cjs/adapters/mcp-tools.d.ts",
+        "default": "./dist/adapters/mcp-tools.cjs"
+      }
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "dev:build-server": "vite build src/server --watch --mode development",
     "dev:build-client": "vite build src/client --watch --mode development",
     "dev:mcp-app": "vite build --config vite.config.mcp-app.ts --watch",
+    "prebuild": "node -e \"require('node:fs').rmSync('dist/cjs', { recursive: true, force: true })\"",
     "build": "npm run build:server && npm run build:mcp-app && npm run build:client && npm run build:adapters && npm run build:cli",
     "build:mcp-app": "vite build --config vite.config.mcp-app.ts && tsx scripts/generate-mcp-app-html.ts",
     "build:server": "vite build --config vite.config.server.ts",

--- a/vite.cjs-marker.ts
+++ b/vite.cjs-marker.ts
@@ -1,0 +1,24 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { Plugin } from 'vite'
+
+/**
+ * Writes `dist/cjs/package.json` = `{ "type": "commonjs" }` so that every
+ * declaration file mirrored into `dist/cjs/` (via vite-plugin-dts `outDirs`) is
+ * interpreted by TypeScript and Node as a CommonJS declaration (the "package
+ * scope" / subdir convention).
+ *
+ * This is what makes the `require.types` entries resolve as CJS instead of
+ * masquerading as ESM (attw `FalseESM`). The mirrored `.d.ts` are byte-for-byte
+ * copies of the ESM ones — their `./x.js` specifiers resolve to sibling CJS
+ * declarations within `dist/cjs/`, so no specifier rewriting is needed. See #881.
+ */
+export function cjsTypesMarker(dir = 'dist/cjs'): Plugin {
+  return {
+    name: 'cjs-types-marker',
+    closeBundle() {
+      mkdirSync(resolve(dir), { recursive: true })
+      writeFileSync(resolve(dir, 'package.json'), '{\n  "type": "commonjs"\n}\n')
+    }
+  }
+}

--- a/vite.cjs-marker.ts
+++ b/vite.cjs-marker.ts
@@ -17,8 +17,9 @@ export function cjsTypesMarker(dir = 'dist/cjs'): Plugin {
   return {
     name: 'cjs-types-marker',
     closeBundle() {
-      mkdirSync(resolve(dir), { recursive: true })
-      writeFileSync(resolve(dir, 'package.json'), '{\n  "type": "commonjs"\n}\n')
+      const cjsDir = resolve(dir)
+      mkdirSync(cjsDir, { recursive: true })
+      writeFileSync(resolve(cjsDir, 'package.json'), '{\n  "type": "commonjs"\n}\n')
     }
   }
 }

--- a/vite.config.adapters.ts
+++ b/vite.config.adapters.ts
@@ -1,19 +1,23 @@
 import { defineConfig } from 'vite'
 import { resolve } from 'path'
 import dts from 'vite-plugin-dts'
+import { cjsTypesMarker } from './vite.cjs-marker'
 
 export default defineConfig({
   plugins: [
     dts({
       // Per-file declarations rooted at src/adapters so they land flat at
       // dist/adapters/* (e.g. dist/adapters/fastify/index.d.ts) matching
-      // package.json#exports rather than nesting at dist/adapters/adapters.
-      // outDir defaults to vite's build.outDir (dist/adapters). See #877.
+      // package.json#exports rather than nesting at dist/adapters/adapters. #877.
+      // outDirs mirrors the same declarations into dist/cjs/adapters for the
+      // require.types condition (CJS via the dist/cjs/package.json marker). #881.
       insertTypesEntry: false,
       include: ['src/adapters/**/*.ts'],
       exclude: ['src/adapters/index.ts'],
-      entryRoot: 'src/adapters'
-    })
+      entryRoot: 'src/adapters',
+      outDirs: ['dist/adapters', 'dist/cjs/adapters']
+    }),
+    cjsTypesMarker()
   ],
   build: {
     lib: {

--- a/vite.config.client.ts
+++ b/vite.config.client.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 import dts from 'vite-plugin-dts'
 import { visualizer } from 'rollup-plugin-visualizer'
+import { cjsTypesMarker } from './vite.cjs-marker'
 
 const chartModuleNames = new Set([
   'ActivityGridChart',
@@ -58,13 +59,18 @@ export default defineConfig({
   plugins: [
     react(),
     dts({
+      // Client is ESM-only (no require condition), but the server's CJS
+      // declaration graph reaches into the client "island" (client/types,
+      // charts config registry, etc.). Mirror the client declarations into
+      // dist/cjs/client so those CJS references resolve as CJS. See #881.
       insertTypesEntry: true,
       rollupTypes: false,
       include: ['src/client/**/*.ts', 'src/client/**/*.tsx'],
       tsconfigPath: './tsconfig.client.json',
-      outDir: 'dist/client',
+      outDirs: ['dist/client', 'dist/cjs/client'],
       entryRoot: 'src/client'
     }),
+    cjsTypesMarker(),
     visualizer({
       filename: 'dist/client-bundle-stats.html',
       open: false,

--- a/vite.config.server.ts
+++ b/vite.config.server.ts
@@ -1,19 +1,23 @@
 import { defineConfig } from 'vite'
 import { resolve } from 'path'
 import dts from 'vite-plugin-dts'
+import { cjsTypesMarker } from './vite.cjs-marker'
 
 export default defineConfig({
   plugins: [
     dts({
       // Emit one .d.ts per source file (NOT a bundled rollup) so declarations
       // resolve under moduleResolution: nodenext/node16. entryRoot keeps the
-      // output flat at dist/server/* matching package.json#exports. outDir
-      // defaults to vite's build.outDir (dist/server). See #877.
+      // output flat at dist/server/* matching package.json#exports. See #877.
+      // outDirs mirrors the same declarations into dist/cjs/server for the
+      // require.types condition (CJS via the dist/cjs/package.json marker). #881.
       insertTypesEntry: true,
       include: ['src/server/**/*.ts'],
       tsconfigPath: './tsconfig.server.json',
-      entryRoot: 'src/server'
-    })
+      entryRoot: 'src/server',
+      outDirs: ['dist/server', 'dist/cjs/server']
+    }),
+    cjsTypesMarker()
   ],
   build: {
     lib: {


### PR DESCRIPTION
## Summary

Fixes the `FalseESM` ("👺 Masquerading as ESM") flag from #881 for CJS `require()` consumers — **without a custom codegen script and without a new dependency**.

The entries with a `require` condition (`.`, `./server`, every `./adapters/*`, `./mcp`) shipped only ESM-flavored `.d.ts`, so a CJS `require()` consumer got ESM-shaped declarations describing a CJS module.

## Approach — the subdir convention, via the existing `vite-plugin-dts`

- Each declaration build (`server`, `adapters`, `client`) mirrors its `.d.ts` into `dist/cjs/<area>` using `vite-plugin-dts`'s native `outDirs`. The mirror is a **verbatim copy** — `./x.js` specifiers are left untouched.
- A tiny shared plugin (`vite.cjs-marker.ts`) writes `dist/cjs/package.json` = `{ "type": "commonjs" }`. That single marker makes every mirrored `.d.ts` resolve as **CommonJS** (package-scope / subdir convention), so `./x.js` specifiers resolve to sibling CJS declarations inside `dist/cjs/` — **no `.d.cts`, no specifier rewriting, no `TS1479`.**
- `package.json#exports`: each CJS entry becomes nested conditional, with `require.types` → `./dist/cjs/.../index.d.ts` and `require` (runtime) keeping the **existing** `.cjs`. The `import` side is unchanged. **No runtime/layout change.**
- The client decl tree is mirrored too, because the server's CJS graph reaches the client "island" (`client/types`, the chart config registry). Client runtime stays ESM-only.

## Why this instead of a `.d.cts` script (cf. #893)

`unplugin-dts`'s `moduleFormat: 'cjs'` only *renames* to `.d.cts`; it copies content verbatim and does **not** rewrite `./x.js`→`./x.cjs`, so a naive `.d.cts` tree hits `TS1479`. That verbatim-copy behavior is exactly what the subdir convention wants — which is why this needs **no rewriting regex and no new tooling**, just the plugin already in `devDependencies`.

## Verification (clean build)

```
npm run build         # ✓
npm run check:exports  # attw --pack . → exit 0,  publint --level error → "All good!"
npm run typecheck      # ✓
npm run lint           # ✓
```

attw now reports for `.`, `./server`, all `./adapters/*`, `./mcp`:

```
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler:           🟢
```

`.attw.json`: the **`false-esm` suppression is removed**. The remaining `cjs-resolves-to-esm` ignore is **retained intentionally** — it is the legitimate, correct state of the **ESM-only client** entries (no `require` condition; a CJS consumer reaches them via dynamic import). It is not a masquerade and can't be removed without shipping a CJS client runtime.

## Notes

- `dist/cjs/` is published via the existing `files: ["dist/"]`; no `files` change needed.
- Minor: `dist/cjs/` is not `emptyOutDir`'d between incremental local builds (a per-build clean conflicts with the plugin's async write). Harmless for clean CI/publish builds; can add a single top-level clean if desired.
- **Out of scope / for maintainers:** whether to keep CJS at all vs. going ESM-only (Option C in #881). On modern Node, `require(esm)` already serves CJS callers of this package at runtime. This PR is the cleanest mechanism *if* CJS support is kept; happy to close in favor of an ESM-only direction.

Alternative to #893 (same attw end-state, cleaner mechanism: no script, no new dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
