### PR TITLE
feat(client): unified chartRegistry with Bar migrated end-to-end (#910)

### DIFF
--- a/src/client/charts/ChartLoader.tsx
+++ b/src/client/charts/ChartLoader.tsx
@@ -18,13 +18,22 @@ import {
   createSafeImport,
   createUnknownChartFallback
 } from './chartComponentRegistry.js'
+// Dynamic import functions for built-in chart **components** (the DOM-bearing,
+// client-only side of a chart). This stays separate from `chartRegistry` — which
+// is DOM-free and shared with the server — so importing the unified registry
+// never drags the chart component graph into server/agent code. Lazy loading is
+// a client-only optimisation.
 
 // The custom-chart registration API lives in chartComponentRegistry to avoid an
 // import cycle (chartPlugin → ChartLoader → DataTable → CubeProvider → chartPlugin).
 // Re-exported here so existing import paths keep working.
 export { registerChartComponent, unregisterChartComponent } from './chartComponentRegistry.js'
 
-// Dynamic import functions for built-in chart types
+// Dynamic import functions for built-in chart **components** — the DOM-bearing,
+// client-only side of a chart. Kept separate from the unified `chartRegistry`
+// (which is DOM-free and shared with the server agent) so importing the registry
+// never drags the chart component graph into server/MCP/agent code. Lazy loading
+// is a client-only optimisation.
 const chartImportMap: Record<BuiltInChartType, () => Promise<{ default: LazyChartComponent }>> = {
   bar: () => import('../components/charts/BarChart.js'),
   line: () => import('../components/charts/LineChart.js'),
@@ -71,7 +80,7 @@ function getLazyChart(chartType: ChartType): LazyExoticComponent<LazyChartCompon
     return chartLoaderCache.get(chartType)!
   }
 
-  // 3. Check built-in import map
+  // 3. Check built-in import map (the client component registry)
   const importFn = chartImportMap[chartType as BuiltInChartType]
   if (importFn) {
     const safeImport = createSafeImport(chartType, importFn)

--- a/src/client/charts/chartComponentRegistry.tsx
+++ b/src/client/charts/chartComponentRegistry.tsx
@@ -14,6 +14,9 @@ import { lazy, ComponentType, LazyExoticComponent } from 'react'
 import type { BuiltInChartType, ChartType, ChartProps } from '../types.js'
 import { MissingDependencyFallback } from '../components/charts/MissingDependencyFallback.js'
 import { useTranslation } from '../hooks/useTranslation.js'
+// chartRegistry only imports pure helpers at runtime, so this stays free of the
+// import-map cycle that this module is careful to avoid.
+import { chartRegistry } from './chartRegistry.js'
 
 // Type for lazy-loaded chart components
 export type LazyChartComponent = ComponentType<ChartProps>
@@ -32,11 +35,8 @@ export const customChartMap = new Map<string, LazyExoticComponent<LazyChartCompo
  * Charts not listed here have no external dependencies (table, KPIs, markdown).
  */
 export const chartDependencyMap: Partial<Record<BuiltInChartType, { packageName: string; installCommand: string }>> = {
-  // Recharts-based charts
-  bar: {
-    packageName: 'recharts',
-    installCommand: 'npm install recharts'
-  },
+  // Recharts-based charts.
+  // Migrated charts (e.g. bar) declare deps on their chartRegistry entry instead.
   line: {
     packageName: 'recharts',
     installCommand: 'npm install recharts'
@@ -125,7 +125,10 @@ export function createUnknownChartFallback(chartType: string): LazyChartComponen
  * Creates a fallback component for a chart type with missing dependencies.
  */
 export function createFallbackComponent(chartType: ChartType): LazyChartComponent {
-  const depInfo = chartDependencyMap[chartType as BuiltInChartType]
+  // Migrated charts declare deps on their chartRegistry entry; fall back to the legacy map.
+  const depInfo =
+    chartRegistry[chartType as BuiltInChartType]?.dependencies ??
+    chartDependencyMap[chartType as BuiltInChartType]
 
   const FallbackComponent: LazyChartComponent = ({ height }) => (
     <MissingDependencyFallback

--- a/src/client/charts/chartConfigRegistry.ts
+++ b/src/client/charts/chartConfigRegistry.ts
@@ -25,7 +25,7 @@ import { candlestickChartConfig } from '../components/charts/CandlestickChart.co
 import { measureProfileChartConfig } from '../components/charts/MeasureProfileChart.config.js'
 import { gaugeChartConfig } from '../components/charts/GaugeChart.config.js'
 import type { ChartTypeConfig, ChartConfigRegistry } from './chartConfigs.js'
-import { chartRegistry, toEagerConfig } from './chartRegistry.js'
+import { chartRegistry, composeChartConfig } from './chartRegistry.js'
 
 /**
  * Registry of all chart type configurations (the eager / full / server source).
@@ -36,7 +36,7 @@ import { chartRegistry, toEagerConfig } from './chartRegistry.js'
  * the server agent reads them synchronously for validation and tool guidance.
  */
 export const chartConfigRegistry: ChartConfigRegistry = {
-  bar: toEagerConfig(chartRegistry.bar!, barChartConfig),
+  bar: composeChartConfig(chartRegistry.bar!, barChartConfig),
   line: lineChartConfig,
   area: areaChartConfig,
   pie: pieChartConfig,

--- a/src/client/charts/chartConfigRegistry.ts
+++ b/src/client/charts/chartConfigRegistry.ts
@@ -25,12 +25,18 @@ import { candlestickChartConfig } from '../components/charts/CandlestickChart.co
 import { measureProfileChartConfig } from '../components/charts/MeasureProfileChart.config.js'
 import { gaugeChartConfig } from '../components/charts/GaugeChart.config.js'
 import type { ChartTypeConfig, ChartConfigRegistry } from './chartConfigs.js'
+import { chartRegistry, toEagerConfig } from './chartRegistry.js'
 
 /**
- * Registry of all chart type configurations
+ * Registry of all chart type configurations (the eager / full / server source).
+ *
+ * Migrated charts compose their entry's metadata (single source of truth) over
+ * their full config shape via `toEagerConfig`; the rest read their full
+ * `*.config.ts` directly. Drop zones / display options stay here in full because
+ * the server agent reads them synchronously for validation and tool guidance.
  */
 export const chartConfigRegistry: ChartConfigRegistry = {
-  bar: barChartConfig,
+  bar: toEagerConfig(chartRegistry.bar!, barChartConfig),
   line: lineChartConfig,
   area: areaChartConfig,
   pie: pieChartConfig,

--- a/src/client/charts/chartRegistry.ts
+++ b/src/client/charts/chartRegistry.ts
@@ -1,0 +1,103 @@
+/**
+ * Unified Chart Registry — the single source of truth for a chart type.
+ *
+ * Historically, adding a chart required coordinated edits across four central
+ * registries (eager config, lazy config, the loader, the icon map) plus the
+ * per-chart component/config/helper/icon files, with the same dynamic-import
+ * path repeated three times. A typo in one failed silently.
+ *
+ * `chartRegistry` collapses that into one entry per chart. The eager config
+ * registry, the lazy config registry, the icon lookup, and the dependency map
+ * become **derived** from this map. Charts not yet migrated keep working off the
+ * legacy registries — `Partial<Record<…>>` models that half-migrated state and
+ * the `| undefined` from a lookup drives the legacy fallback.
+ *
+ * Client/server boundary: this module is DOM-free so the server agent and the
+ * eager config registry can import it. The React **component** thunk (which
+ * pulls recharts / ChartContainer / DOM globals) is a client-only concern and
+ * lives in the loader's component map — NOT here. Lazy loading is purely a
+ * client optimisation; server/MCP/agent code reads the eager config directly.
+ *
+ * Slice 1 (issue #910) migrates Bar end-to-end as the tracer.
+ */
+
+import type { BuiltInChartType } from '../types.js'
+import type { IconName } from '../icons/types.js'
+import type {
+  ChartTypeConfig,
+  ChartAvailabilityContext,
+  ChartAvailability,
+} from './chartConfigs.js'
+import { requiresMeasureAndDimension } from './chartConfigHelpers.js'
+import { setRegistryIconResolver } from '../icons/registry.js'
+
+/**
+ * The single source of truth for one chart type's DOM-free metadata: the eager
+ * picker fields, the lazy config thunk, the icon name, and dependency info.
+ *
+ * The React component thunk is deliberately NOT part of the entry — it is the
+ * one DOM-bearing piece and is owned by the client loader, keeping this entry
+ * (and its consumers, incl. the server agent) free of the chart component graph.
+ */
+export interface ChartRegistryEntry {
+  /** Display label for the picker — an i18n key, resolved at render time. */
+  label: string
+  /** Icon name resolved via the icon registry (override-able via registerIcons/setIcon). */
+  icon: IconName
+  /** Brief description — i18n key. */
+  description?: string
+  /** When to use this chart — i18n key. */
+  useCase?: string
+  /** Whether the chart can render with the current query shape. */
+  isAvailable?: (ctx: ChartAvailabilityContext) => ChartAvailability
+  /** Optional peer dependency — shows install instructions if the import fails. */
+  dependencies?: { packageName: string; installCommand: string }
+  /** Lazy config import — resolves the config OBJECT directly (client lazy path). */
+  config: () => Promise<ChartTypeConfig>
+}
+
+/**
+ * The unified registry. Typed `Partial` while migration is in progress: only
+ * migrated charts have an entry; everything else falls back to the legacy maps.
+ * Slice 2 drops `Partial` → `Record` and deletes the dead fallbacks.
+ */
+export const chartRegistry: Partial<Record<BuiltInChartType, ChartRegistryEntry>> = {
+  bar: {
+    label: 'chart.bar.label',
+    icon: 'chartBar',
+    description: 'chart.bar.description',
+    useCase: 'chart.bar.useCase',
+    isAvailable: requiresMeasureAndDimension,
+    dependencies: {
+      packageName: 'recharts',
+      installCommand: 'npm install recharts',
+    },
+    config: async () => (await import('../components/charts/BarChart.config.js')).barChartConfig,
+  },
+}
+
+// Wire the icon resolver so getChartTypeIcon() derives migrated charts' icons
+// from their entry, without the icon module statically depending on this one.
+// Mirrors the `setCustomChartIconResolver` plugin pattern.
+setRegistryIconResolver((chartType) => chartRegistry[chartType as BuiltInChartType]?.icon)
+
+/**
+ * Derives the eager `chartConfigRegistry` value for a migrated chart: the
+ * entry's metadata composed over the chart's full config shape (`base`).
+ *
+ * The eager config is the server/full source — read synchronously for the
+ * picker (label/description/useCase/isAvailable) AND by the server agent's chart
+ * validation + tool guidance (dropZones/skipQuery). So it must stay fully
+ * populated; `base` supplies the real drop zones and display options, while the
+ * entry supplies the metadata (its single declaration site). The client's lazy
+ * path resolves the same `base` via the entry's `config` thunk.
+ */
+export function toEagerConfig(entry: ChartRegistryEntry, base: ChartTypeConfig): ChartTypeConfig {
+  return {
+    ...base,
+    label: entry.label,
+    description: entry.description,
+    useCase: entry.useCase,
+    isAvailable: entry.isAvailable,
+  }
+}

--- a/src/client/charts/chartRegistry.ts
+++ b/src/client/charts/chartRegistry.ts
@@ -82,17 +82,19 @@ export const chartRegistry: Partial<Record<BuiltInChartType, ChartRegistryEntry>
 setRegistryIconResolver((chartType) => chartRegistry[chartType as BuiltInChartType]?.icon)
 
 /**
- * Derives the eager `chartConfigRegistry` value for a migrated chart: the
- * entry's metadata composed over the chart's full config shape (`base`).
+ * Composes a migrated chart's full `ChartTypeConfig` from its entry: the entry's
+ * metadata (its single declaration site) laid over the chart's config shape
+ * (`base` — drop zones, display options, clickable elements, validation).
  *
- * The eager config is the server/full source — read synchronously for the
- * picker (label/description/useCase/isAvailable) AND by the server agent's chart
- * validation + tool guidance (dropZones/skipQuery). So it must stay fully
- * populated; `base` supplies the real drop zones and display options, while the
- * entry supplies the metadata (its single declaration site). The client's lazy
- * path resolves the same `base` via the entry's `config` thunk.
+ * Used by BOTH derivation paths so they return the same full shape as a
+ * non-migrated chart's `*.config.ts`:
+ * - eager `chartConfigRegistry` (server/full source — read synchronously for the
+ *   picker AND by the server agent's chart validation + tool guidance), with
+ *   `base` = the statically-imported config;
+ * - lazy `getChartConfigAsync` (client code-split path), with `base` = the
+ *   config resolved from the entry's `config` thunk.
  */
-export function toEagerConfig(entry: ChartRegistryEntry, base: ChartTypeConfig): ChartTypeConfig {
+export function composeChartConfig(entry: ChartRegistryEntry, base: ChartTypeConfig): ChartTypeConfig {
   return {
     ...base,
     label: entry.label,

--- a/src/client/charts/lazyChartConfigRegistry.ts
+++ b/src/client/charts/lazyChartConfigRegistry.ts
@@ -9,10 +9,12 @@ import { useState, useEffect } from 'react'
 import type { BuiltInChartType, ChartType } from '../types.js'
 import type { ChartTypeConfig, ChartConfigRegistry } from './chartConfigs.js'
 import { defaultChartConfig } from './chartConfigs.js'
+import { chartRegistry } from './chartRegistry.js'
 
-// Config import map - lazy imports for built-in chart configs
-const configImportMap: Record<BuiltInChartType, () => Promise<{ [key: string]: ChartTypeConfig }>> = {
-  bar: () => import('../components/charts/BarChart.config.js'),
+// Config import map - lazy imports for built-in chart configs.
+// Migrated charts (e.g. bar) resolve via their `chartRegistry` entry's `config`
+// thunk instead — their import path is defined once, in the entry.
+const configImportMap: Partial<Record<BuiltInChartType, () => Promise<{ [key: string]: ChartTypeConfig }>>> = {
   line: () => import('../components/charts/LineChart.config.js'),
   area: () => import('../components/charts/AreaChart.config.js'),
   pie: () => import('../components/charts/PieChart.config.js'),
@@ -40,9 +42,9 @@ const configImportMap: Record<BuiltInChartType, () => Promise<{ [key: string]: C
   gauge: () => import('../components/charts/GaugeChart.config.js'),
 }
 
-// Map from built-in chart type to expected export name
-const configExportNames: Record<BuiltInChartType, string> = {
-  bar: 'barChartConfig',
+// Map from built-in chart type to expected export name.
+// Migrated charts are absent — they resolve the config object directly via their entry.
+const configExportNames: Partial<Record<BuiltInChartType, string>> = {
   line: 'lineChartConfig',
   area: 'areaChartConfig',
   pie: 'pieChartConfig',
@@ -86,11 +88,29 @@ const configCache = new Map<ChartType, ChartTypeConfig>()
  * ```
  */
 export async function getChartConfigAsync(chartType: ChartType): Promise<ChartTypeConfig | null> {
-  // Check cache first
+  // Check cache first (plugin overrides land here via registerConfigToCache —
+  // their precedence stays ahead of the unified/legacy lookups below).
   if (configCache.has(chartType)) {
     return configCache.get(chartType)!
   }
 
+  // Unified registry: migrated charts resolve the config object directly.
+  const entry = chartRegistry[chartType as BuiltInChartType]
+  if (entry) {
+    try {
+      const config = await entry.config()
+      if (config) {
+        configCache.set(chartType, config)
+        return config
+      }
+      return null
+    } catch (error) {
+      console.error(`Failed to load config for chart type: ${chartType}`, error)
+      return null
+    }
+  }
+
+  // Legacy registry fallback for charts not yet migrated.
   const importFn = configImportMap[chartType as BuiltInChartType]
   if (!importFn) {
     return null
@@ -99,7 +119,7 @@ export async function getChartConfigAsync(chartType: ChartType): Promise<ChartTy
   try {
     const module = await importFn()
     const exportName = configExportNames[chartType as BuiltInChartType]
-    const config = module[exportName]
+    const config = exportName ? module[exportName] : undefined
 
     if (config) {
       configCache.set(chartType, config)
@@ -233,7 +253,10 @@ export async function preloadChartConfigs(chartTypes: ChartType[]): Promise<void
  * ```
  */
 export async function loadAllChartConfigs(): Promise<ChartConfigRegistry> {
-  const chartTypes = Object.keys(configImportMap) as ChartType[]
+  // Union legacy import map with migrated entries so every built-in is covered.
+  const chartTypes = [
+    ...new Set([...Object.keys(configImportMap), ...Object.keys(chartRegistry)]),
+  ] as ChartType[]
   await Promise.all(chartTypes.map(getChartConfigAsync))
 
   const registry: ChartConfigRegistry = {}

--- a/src/client/charts/lazyChartConfigRegistry.ts
+++ b/src/client/charts/lazyChartConfigRegistry.ts
@@ -9,7 +9,7 @@ import { useState, useEffect } from 'react'
 import type { BuiltInChartType, ChartType } from '../types.js'
 import type { ChartTypeConfig, ChartConfigRegistry } from './chartConfigs.js'
 import { defaultChartConfig } from './chartConfigs.js'
-import { chartRegistry } from './chartRegistry.js'
+import { chartRegistry, composeChartConfig } from './chartRegistry.js'
 
 // Config import map - lazy imports for built-in chart configs.
 // Migrated charts (e.g. bar) resolve via their `chartRegistry` entry's `config`
@@ -94,12 +94,15 @@ export async function getChartConfigAsync(chartType: ChartType): Promise<ChartTy
     return configCache.get(chartType)!
   }
 
-  // Unified registry: migrated charts resolve the config object directly.
+  // Unified registry: migrated charts resolve the config object directly, then
+  // compose the entry metadata over it so the lazy public API returns the same
+  // full shape (label/description/useCase/isAvailable) as non-migrated charts.
   const entry = chartRegistry[chartType as BuiltInChartType]
   if (entry) {
     try {
-      const config = await entry.config()
-      if (config) {
+      const base = await entry.config()
+      if (base) {
+        const config = composeChartConfig(entry, base)
         configCache.set(chartType, config)
         return config
       }

--- a/src/client/components/charts/BarChart.config.ts
+++ b/src/client/components/charts/BarChart.config.ts
@@ -1,6 +1,5 @@
 import type { ChartTypeConfig } from '../../charts/chartConfigs.js'
 import {
-  requiresMeasureAndDimension,
   stackTypeDisplayOption,
   targetDisplayOption,
   leftYAxisFormatDisplayOption,
@@ -8,14 +7,15 @@ import {
 } from '../../charts/chartConfigHelpers.js'
 
 /**
- * Configuration for the bar chart type
+ * Configuration for the bar chart type.
+ *
+ * Eager metadata (`label`, `description`, `useCase`, `isAvailable`) lives in the
+ * unified `chartRegistry` entry (the single source of truth) — see
+ * `src/client/charts/chartRegistry.ts`. This file owns the lazy-loaded shape:
+ * drop zones, display options, clickable elements, validation.
  */
 export const barChartConfig: ChartTypeConfig = {
-  label: 'chart.bar.label',
-  description: 'chart.bar.description',
-  useCase: 'chart.bar.useCase',
   clickableElements: { bar: true },
-  isAvailable: requiresMeasureAndDimension,
   dropZones: [
     {
       key: 'xAxis',

--- a/src/client/icons/registry.tsx
+++ b/src/client/icons/registry.tsx
@@ -196,7 +196,15 @@ export function getMeasureTypeIcon(measureType: string | undefined): ComponentTy
  * @returns React component for the icon
  */
 export function getChartTypeIcon(chartType: string): ComponentType<IconProps> {
-  // Unified registry first: migrated charts declare their icon on the entry
+  // Plugin overrides win first (hard precedence requirement): a custom chart —
+  // including one overriding a built-in like `bar` — may supply its own icon,
+  // which must take priority over the unified-registry and legacy lookups below.
+  if (_customIconResolver) {
+    const customIcon = _customIconResolver(chartType)
+    if (customIcon) return customIcon
+  }
+
+  // Unified registry: migrated charts declare their icon on the entry
   // (theme-overridable via the icon registry). Falls back to the legacy typeMap.
   const entryIcon = _registryIconResolver?.(chartType)
   if (entryIcon) {
@@ -227,12 +235,6 @@ export function getChartTypeIcon(chartType: string): ComponentType<IconProps> {
   const iconName = typeMap[chartType]
   if (iconName) {
     return getIcon(iconName)
-  }
-
-  // Check custom chart plugin icon resolver (set by chartPlugin.ts to avoid circular imports)
-  if (_customIconResolver) {
-    const customIcon = _customIconResolver(chartType)
-    if (customIcon) return customIcon
   }
 
   return getIcon('chartBar')

--- a/src/client/icons/registry.tsx
+++ b/src/client/icons/registry.tsx
@@ -26,6 +26,24 @@ export function setCustomChartIconResolver(
   _customIconResolver = resolver
 }
 
+// Resolver for icon names declared on unified chartRegistry entries (set by
+// chartRegistry.ts via setRegistryIconResolver). Injected rather than imported
+// so this foundational icon module stays free of the chart component graph —
+// statically importing chartRegistry would drag BarChart/ChartContainer into
+// every program that includes icons (incl. the DOM-less server-tests config).
+let _registryIconResolver: ((chartType: string) => IconName | undefined) | null = null
+
+/**
+ * Set the resolver that maps a chart type to its unified-registry icon name.
+ * Called by chartRegistry.ts during initialization.
+ * @internal
+ */
+export function setRegistryIconResolver(
+  resolver: (chartType: string) => IconName | undefined
+): void {
+  _registryIconResolver = resolver
+}
+
 // Cache for icon components to avoid recreating on every getIcon() call
 // This prevents React from unmounting/remounting icons on each render
 const _iconComponentCache = new Map<IconName, ComponentType<IconProps>>()
@@ -178,8 +196,14 @@ export function getMeasureTypeIcon(measureType: string | undefined): ComponentTy
  * @returns React component for the icon
  */
 export function getChartTypeIcon(chartType: string): ComponentType<IconProps> {
+  // Unified registry first: migrated charts declare their icon on the entry
+  // (theme-overridable via the icon registry). Falls back to the legacy typeMap.
+  const entryIcon = _registryIconResolver?.(chartType)
+  if (entryIcon) {
+    return getIcon(entryIcon)
+  }
+
   const typeMap: Record<string, IconName> = {
-    bar: 'chartBar',
     line: 'chartLine',
     area: 'chartArea',
     pie: 'chartPie',

--- a/tests/client/charts/chartRegistry.test.ts
+++ b/tests/client/charts/chartRegistry.test.ts
@@ -11,7 +11,7 @@ import '@testing-library/jest-dom'
 import { screen } from '@testing-library/react'
 import { createElement } from 'react'
 import { renderWithProviders } from '../../client-setup/test-utils'
-import { chartRegistry, toEagerConfig } from '../../../src/client/charts/chartRegistry'
+import { chartRegistry, composeChartConfig } from '../../../src/client/charts/chartRegistry'
 import { chartConfigRegistry } from '../../../src/client/charts/chartConfigRegistry'
 import { barChartConfig } from '../../../src/client/components/charts/BarChart.config'
 import {
@@ -45,20 +45,20 @@ describe('chartRegistry — entry shape', () => {
   })
 })
 
-describe('chartRegistry — toEagerConfig', () => {
+describe('chartRegistry — composeChartConfig', () => {
   it('composes the entry metadata over the full config shape', () => {
     const bar = chartRegistry.bar!
-    const eager = toEagerConfig(bar, barChartConfig)
+    const composed = composeChartConfig(bar, barChartConfig)
 
     // Metadata comes from the entry (its single declaration site)...
-    expect(eager.label).toBe('chart.bar.label')
-    expect(eager.description).toBe('chart.bar.description')
-    expect(eager.useCase).toBe('chart.bar.useCase')
-    expect(eager.isAvailable).toBe(bar.isAvailable)
+    expect(composed.label).toBe('chart.bar.label')
+    expect(composed.description).toBe('chart.bar.description')
+    expect(composed.useCase).toBe('chart.bar.useCase')
+    expect(composed.isAvailable).toBe(bar.isAvailable)
     // ...while the real drop zones / display options come from the config shape,
-    // so the eager (server/full) config stays usable for agent validation.
-    expect(eager.dropZones.map((z) => z.key)).toEqual(['xAxis', 'yAxis', 'series'])
-    expect(eager.clickableElements).toEqual({ bar: true })
+    // so the composed config stays usable for agent validation + the config panel.
+    expect(composed.dropZones.map((z) => z.key)).toEqual(['xAxis', 'yAxis', 'series'])
+    expect(composed.clickableElements).toEqual({ bar: true })
   })
 })
 
@@ -89,6 +89,19 @@ describe('chartRegistry — lazy config derivation (site 2)', () => {
     expect(config).not.toBeNull()
     expect(config!.dropZones.length).toBeGreaterThan(0)
     expect(config!.dropZones.map((z) => z.key)).toEqual(['xAxis', 'yAxis', 'series'])
+  })
+
+  it('composes the entry metadata over the lazy config so the public shape is complete', async () => {
+    // Public lazy API parity: getChartConfigAsync must return the same full
+    // metadata-bearing shape as non-migrated charts, not the stripped *.config.ts.
+    clearChartConfigCache()
+    const entry = chartRegistry.bar!
+    const config = await getChartConfigAsync('bar')
+
+    expect(config!.label).toBe(entry.label)
+    expect(config!.description).toBe(entry.description)
+    expect(config!.useCase).toBe(entry.useCase)
+    expect(config!.isAvailable).toBe(entry.isAvailable)
   })
 
   it('still resolves a sibling chart (line) via the legacy registry', async () => {

--- a/tests/client/charts/chartRegistry.test.ts
+++ b/tests/client/charts/chartRegistry.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the unified chartRegistry — the single source of truth for a chart.
+ *
+ * Slice 1 (issue #910) migrates Bar end-to-end through chartRegistry while every
+ * other chart keeps working off the legacy registries. These tests assert the
+ * entry shape and that all five derivation sites read Bar from the one entry.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import '@testing-library/jest-dom'
+import { screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { renderWithProviders } from '../../client-setup/test-utils'
+import { chartRegistry, toEagerConfig } from '../../../src/client/charts/chartRegistry'
+import { chartConfigRegistry } from '../../../src/client/charts/chartConfigRegistry'
+import { barChartConfig } from '../../../src/client/components/charts/BarChart.config'
+import {
+  getChartConfigAsync,
+  clearChartConfigCache,
+} from '../../../src/client/charts/lazyChartConfigRegistry'
+import {
+  isValidChartType,
+  getAvailableChartTypes,
+} from '../../../src/client/charts/ChartLoader'
+import { getChartTypeIcon, getIcon } from '../../../src/client/icons/registry'
+import { createFallbackComponent } from '../../../src/client/charts/chartComponentRegistry'
+import { chartPluginRegistry } from '../../../src/client/charts/chartPlugin'
+import type { ChartProps } from '../../../src/client/types'
+
+describe('chartRegistry — entry shape', () => {
+  it('has a bar entry that is the single source of truth (DOM-free)', () => {
+    const bar = chartRegistry.bar
+    expect(bar).toBeDefined()
+    expect(bar!.label).toBe('chart.bar.label')
+    expect(bar!.icon).toBe('chartBar')
+    expect(typeof bar!.config).toBe('function')
+    expect(typeof bar!.isAvailable).toBe('function')
+    expect(bar!.dependencies).toEqual({
+      packageName: 'recharts',
+      installCommand: 'npm install recharts',
+    })
+    // The DOM-bearing React component thunk is intentionally NOT on the entry —
+    // it is a client-only concern owned by the loader's component map.
+    expect('component' in bar!).toBe(false)
+  })
+})
+
+describe('chartRegistry — toEagerConfig', () => {
+  it('composes the entry metadata over the full config shape', () => {
+    const bar = chartRegistry.bar!
+    const eager = toEagerConfig(bar, barChartConfig)
+
+    // Metadata comes from the entry (its single declaration site)...
+    expect(eager.label).toBe('chart.bar.label')
+    expect(eager.description).toBe('chart.bar.description')
+    expect(eager.useCase).toBe('chart.bar.useCase')
+    expect(eager.isAvailable).toBe(bar.isAvailable)
+    // ...while the real drop zones / display options come from the config shape,
+    // so the eager (server/full) config stays usable for agent validation.
+    expect(eager.dropZones.map((z) => z.key)).toEqual(['xAxis', 'yAxis', 'series'])
+    expect(eager.clickableElements).toEqual({ bar: true })
+  })
+})
+
+describe('chartRegistry — eager chartConfigRegistry derivation (site 1)', () => {
+  it('derives the eager bar config from the single entry, keeping real drop zones', () => {
+    const entry = chartRegistry.bar!
+    const eager = chartConfigRegistry.bar
+
+    expect(eager.label).toBe(entry.label)
+    expect(eager.description).toBe(entry.description)
+    expect(eager.useCase).toBe(entry.useCase)
+    expect(eager.isAvailable).toBe(entry.isAvailable)
+    // Eager config is the server/full source — must retain real drop zones for
+    // the agent's mandatory-zone validation and tool guidance.
+    expect(eager.dropZones.map((z) => z.key)).toEqual(['xAxis', 'yAxis', 'series'])
+  })
+
+  it('keeps the label as a translation key, not resolved text', () => {
+    expect(chartConfigRegistry.bar.label).toBe('chart.bar.label')
+  })
+})
+
+describe('chartRegistry — lazy config derivation (site 2)', () => {
+  it('resolves the real, non-empty dropZones for bar via the entry config thunk', async () => {
+    clearChartConfigCache()
+    const config = await getChartConfigAsync('bar')
+
+    expect(config).not.toBeNull()
+    expect(config!.dropZones.length).toBeGreaterThan(0)
+    expect(config!.dropZones.map((z) => z.key)).toEqual(['xAxis', 'yAxis', 'series'])
+  })
+
+  it('still resolves a sibling chart (line) via the legacy registry', async () => {
+    clearChartConfigCache()
+    const config = await getChartConfigAsync('line')
+    expect(config).not.toBeNull()
+    expect(config!.dropZones.length).toBeGreaterThan(0)
+  })
+})
+
+describe('chartRegistry — loader (client component map)', () => {
+  // The component thunk is the one DOM-bearing, client-only piece, so it stays
+  // in the loader's component map rather than the shared (server-safe) entry.
+  it('recognizes bar as a valid chart type', () => {
+    expect(isValidChartType('bar')).toBe(true)
+  })
+
+  it('lists bar among available chart types', () => {
+    expect(getAvailableChartTypes()).toContain('bar')
+  })
+
+  it('still recognizes a sibling chart (line)', () => {
+    expect(isValidChartType('line')).toBe(true)
+    expect(getAvailableChartTypes()).toContain('line')
+  })
+})
+
+describe('chartRegistry — icon derivation (site 4)', () => {
+  it('resolves the bar icon from the entry, identical to the registered icon', () => {
+    expect(getChartTypeIcon('bar')).toBe(getIcon('chartBar'))
+  })
+
+  it('still resolves a sibling chart (line) icon via the legacy typeMap', () => {
+    expect(getChartTypeIcon('line')).toBe(getIcon('chartLine'))
+  })
+})
+
+describe('chartRegistry — dependency derivation (site 5)', () => {
+  it('builds the missing-dependency fallback for bar from the entry deps', () => {
+    // After bar is removed from the legacy chartDependencyMap, its deps must
+    // still resolve via the entry — the fallback shows recharts, not "unknown".
+    const Fallback = createFallbackComponent('bar')
+    renderWithProviders(createElement(Fallback, { data: [] }))
+    expect(screen.getByText('npm install recharts')).toBeInTheDocument()
+  })
+})
+
+describe('chartRegistry — plugin override precedence (regression)', () => {
+  const CustomBar = ({ data }: ChartProps) =>
+    createElement('div', { 'data-testid': 'custom-bar' }, `rows:${data?.length ?? 0}`)
+
+  afterEach(() => {
+    chartPluginRegistry.unregister('bar')
+    clearChartConfigCache()
+  })
+
+  it('lets a custom bar override win over the migrated built-in, then restores it', async () => {
+    chartPluginRegistry.register({
+      type: 'bar',
+      label: 'Custom Bar',
+      component: CustomBar,
+      config: {
+        label: 'Custom Bar',
+        dropZones: [{ key: 'custom', label: 'Custom Zone', acceptTypes: ['measure'] }],
+      },
+    })
+
+    // Eager registry + async config both reflect the override (cache precedence
+    // stays ahead of the unified entry lookup).
+    expect(chartConfigRegistry.bar.label).toBe('Custom Bar')
+    expect(chartPluginRegistry.isCustom('bar')).toBe(true)
+    const overridden = await getChartConfigAsync('bar')
+    expect(overridden!.dropZones.map((z) => z.key)).toEqual(['custom'])
+
+    // Unregistering restores the built-in derived from the entry.
+    chartPluginRegistry.unregister('bar')
+    clearChartConfigCache()
+    expect(chartConfigRegistry.bar.label).toBe('chart.bar.label')
+    const restored = await getChartConfigAsync('bar')
+    expect(restored!.dropZones.map((z) => z.key)).toEqual(['xAxis', 'yAxis', 'series'])
+  })
+})

--- a/tests/client/charts/chartRegistry.test.ts
+++ b/tests/client/charts/chartRegistry.test.ts
@@ -183,4 +183,22 @@ describe('chartRegistry — plugin override precedence (regression)', () => {
     const restored = await getChartConfigAsync('bar')
     expect(restored!.dropZones.map((z) => z.key)).toEqual(['xAxis', 'yAxis', 'series'])
   })
+
+  it('lets a custom bar icon override win over the unified entry icon, then restores it', () => {
+    const CustomIcon = () => createElement('svg', { 'data-testid': 'custom-bar-icon' })
+
+    chartPluginRegistry.register({
+      type: 'bar',
+      label: 'Custom Bar',
+      component: CustomBar,
+      icon: CustomIcon,
+      config: { label: 'Custom Bar', dropZones: [] },
+    })
+
+    // Plugin icon precedence must stay ahead of the unified entry lookup.
+    expect(getChartTypeIcon('bar')).toBe(CustomIcon)
+
+    chartPluginRegistry.unregister('bar')
+    expect(getChartTypeIcon('bar')).toBe(getIcon('chartBar'))
+  })
 })


### PR DESCRIPTION
Closes #910.

Introduces a single `chartRegistry` map keyed by chart type as the source of truth for a chart's DOM-free concerns, and migrates **Bar** through it end-to-end. The eager config, lazy config, icon, and dependency lookups for Bar all derive from its one entry; every other chart keeps working off the legacy registries (`Partial<Record<…>>` models the half-migrated state).

## What changed
- **`src/client/charts/chartRegistry.ts`** (new) — `ChartRegistryEntry` type, the `chartRegistry` map with the `bar` entry, and `toEagerConfig`.
- Eager metadata (`label`/`description`/`useCase`/`isAvailable`) **moved** out of `BarChart.config.ts` into the entry (single source of truth).
- `getChartConfigAsync`, `getChartTypeIcon`, `createFallbackComponent`, and the eager `chartConfigRegistry` derive Bar from the entry, with plugin/cache precedence kept **ahead** of the unified lookup. A custom `bar` override still wins (regression-tested).

## Design decisions (diverging from the issue's resolved design)
Two assumptions in the issue turned out to be wrong against the codebase; both were resolved with the client/server boundary in mind:

1. **The entry is DOM-free — the React `component` thunk is not on it.** The eager `chartConfigRegistry` derives from `chartRegistry`, and the server agent (`src/server/agent/chart-validation.ts`) imports `chartConfigRegistry`. Putting `import('BarChart.js')` on the entry drags `ChartContainer`/recharts/DOM globals into the DOM-less server-tests tsconfig and fails typecheck. The component thunk stays in the client-only `chartImportMap`; the entry holds only DOM-free fields + a lazy `config` thunk. Icon wiring uses `setRegistryIconResolver` injection so `icons/registry.tsx` never statically imports charts.
2. **The eager config keeps real `dropZones`** (not the proposed `dropZones: []` placeholder). `chart-validation.ts` reads `config.dropZones` synchronously for mandatory-zone validation + tool guidance, and the i18n key-coverage test reads them too. `toEagerConfig(entry, base)` composes entry metadata over the full config shape.

Both corrections (and their impact on the cleanup goals) are documented in a comment on the slice-2 follow-up #911.

## Testing
- New `tests/client/charts/chartRegistry.test.ts` — 13 tests covering entry shape, all derivation sites, label-is-a-key, sibling chart still via legacy, and plugin-override precedence.
- Green: `npm run test:client` (162 files / 5874 tests), `npm run typecheck` (all 3 tsconfig projects), `npm run lint`, plus the i18n + agent suites (90 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
