### PR TITLE
docs: agent-skills configuration and domain glossaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,19 @@ From a clean, up-to-date `main`:
 5. Verify: `npm view drizzle-cube version` shows the new version.
 
 Version-only commits skip tests in CI but still run lint/typecheck/build so the publish gate reports success.
+
+## Agent skills
+
+Per-repo configuration for the engineering skills (`to-issues`, `triage`, `to-prd`, `qa`, `improve-codebase-architecture`, `diagnosing-bugs`, `tdd`).
+
+### Issue tracker
+
+Issues live as GitHub issues in `cliftonc/drizzle-cube` (the `origin` remote), managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical triage roles map to repo labels of the same name (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`); categories are `bug` / `enhancement`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Multi-context: `CONTEXT-MAP.md` at the root indexes per-area glossaries (`src/server/`, `src/client/`, `src/adapters/CONTEXT.md`), created lazily by `/domain-modeling`. See `docs/agents/domain.md`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,13 @@
+# Context Map
+
+drizzle-cube is a single package but a multi-area codebase. Domain vocabulary is split per area, mirroring the per-area `CLAUDE.md` files. When a skill needs the ubiquitous language for an area, read that area's `CONTEXT.md`.
+
+| Area | Context glossary | Covers |
+| ---- | ---------------- | ------ |
+| Server / semantic layer | `src/server/CONTEXT.md` | cube, measure, dimension, semantic query, logical/physical plan, executor — the foundational vocabulary the other areas build on |
+| Client / dashboard | `src/client/CONTEXT.md` | dashboard, portlet, chart registry, analysis builder, query mode |
+| Adapters / transport | `src/adapters/CONTEXT.md` | handler protocol, HttpPort, CubeHttpHandler core, MCP transport, security context, locale propagation |
+
+System-wide architectural decisions live in `docs/adr/` at the root; area-specific decisions live in `src/<area>/docs/adr/`.
+
+Glossaries are created **lazily** by `/domain-modeling` as terms get resolved — a missing `CONTEXT.md` is normal. The server and client glossaries will be seeded when their terms next crystallize; the adapters glossary exists now (seeded from the issue-906 grilling).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,48 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This is a **multi-context** repo: a `CONTEXT-MAP.md` at the root points to one `CONTEXT.md` per area, mirroring the per-area `CLAUDE.md` files.
+
+## Before exploring, read these
+
+- **`CONTEXT-MAP.md`** at the repo root — the index of per-area glossaries. Read the `CONTEXT.md` for the area(s) your task touches:
+  - `src/server/CONTEXT.md` — semantic layer / query pipeline (the foundational vocabulary)
+  - `src/client/CONTEXT.md` — dashboard / chart / analysis builder
+  - `src/adapters/CONTEXT.md` — HTTP + MCP transport (handler protocol, HttpPort, etc.)
+- **`docs/adr/`** — system-wide architecture decisions. Also check **`src/<area>/docs/adr/`** for area-specific decisions in the area you're working in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved. The server and client glossaries are created lazily; the adapters glossary already exists.
+
+## File structure
+
+```
+/
+├── CONTEXT-MAP.md                     ← index of per-area glossaries
+├── docs/adr/                          ← system-wide decisions (created lazily)
+└── src/
+    ├── server/
+    │   ├── CONTEXT.md                  ← (created lazily)
+    │   ├── CLAUDE.md
+    │   └── docs/adr/                   ← area-specific decisions (created lazily)
+    ├── client/
+    │   ├── CONTEXT.md                  ← (created lazily)
+    │   └── CLAUDE.md
+    └── adapters/
+        ├── CONTEXT.md                  ← seeded
+        └── CLAUDE.md
+```
+
+Note: the per-area `CLAUDE.md` files are implementation/convention guides, not glossaries — the area's `CONTEXT.md` is the source of domain vocabulary.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in the relevant area's `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in **`cliftonc/drizzle-cube`**. Use the `gh` CLI for all operations.
+
+> This clone has a single `origin` pointing at `cliftonc/drizzle-cube`, so `gh` infers the repo automatically. Passing `-R cliftonc/drizzle-cube` explicitly is still the safest habit if another remote is ever added.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue in `cliftonc/drizzle-cube`.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,22 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker. All five labels exist in `cliftonc/drizzle-cube`.
+
+| Canonical role    | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
+
+The two **category** roles map to existing repo labels:
+
+| Canonical role | Label in our tracker |
+| -------------- | -------------------- |
+| `bug`          | `bug`                |
+| `enhancement`  | `enhancement`        |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from these tables.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/src/adapters/CONTEXT.md
+++ b/src/adapters/CONTEXT.md
@@ -1,0 +1,33 @@
+# Adapters — Domain Glossary
+
+Ubiquitous language for the HTTP + MCP transport layer (`src/adapters/`). Architecture terms (**module, interface, seam, adapter, deep/shallow, leverage, locality**) follow the `/codebase-design` vocabulary. Use these terms exactly in issues, tests, and proposals — don't drift to "service", "API layer", or "boundary".
+
+## Terms
+
+### Handler protocol
+The framework-agnostic **seam** where "an HTTP request becomes a Cube result" lives **once**. Composed of the **HttpPort** interface plus the **CubeHttpHandler core**. Before it, the four framework adapters each re-implemented the same request → query → response flow inline (shallow, duplicated); the handler protocol is the deep module they all translate onto. Introduced incrementally: REST `/load` (issue #906), rest of the endpoints + MCP (#908), all four adapters + SSE (#909).
+
+### HttpPort
+The small, **public** transport **interface** the core runs against — `getHeader`, `getBody`, `getQueryParam`, `send`. Generic over the framework response type (`HttpPort<TRes>`) so `send(status, body)` works whether the framework mutates a response object (Express) or returns one (Hono, Next.js). Deliberately tiny and dumb: `formatErrorResponse` and all decisions live in the core, not the port. Exported via `./adapters/core` so third parties can author adapters for other frameworks.
+
+### CubeHttpHandler core
+The deep **module** behind the handler protocol — `createCubeHttpHandler({ semanticLayer, onError })`. Owns REST orchestration (validate → execute → `formatCubeResponse`), security-context + locale-merge, the `x-cache-control` cache bypass, and all 400-vs-500 mapping. Contains **no framework types**. The interface is the test surface: tested against a fake port with a stubbed `semanticLayer`, no running server.
+
+### Adapter
+In this repo, a **thin per-framework translation** (Express, Fastify, Hono, Next.js) from framework-native `req`/`res` onto the HttpPort, plus route wiring. Adapters should hold no request-handling logic once the handler protocol is fully adopted — that's the deepening goal. (Distinct from a **database adapter** in `src/server/adapters/`, which is engine-specific SQL generation.)
+
+### REST load vs `handleLoad`
+Two intentionally distinct load orchestrations:
+- **REST load** — the HTTP `/load` flavor: no field normalization, validation failure → 400 JSON, honors `x-cache-control: no-cache`, returns `formatCubeResponse(...)`. Owned by the CubeHttpHandler core.
+- **`handleLoad`** (`src/server/query-handlers.ts`) — the MCP/agent flavor: runs `normalizeQueryFields`, **throws** on invalid, no cache control, returns raw `{ data, annotation, query }`. Used by MCP transport, the agent tools, and the Next.js MCP load handler.
+
+They coexist by design; converging them is an open, unticketed decision — do not silently merge them.
+
+### Security context
+The per-request auth/tenant value produced by the user-supplied `extractSecurityContext(req, res)` and threaded into every query for multi-tenant isolation. The user's extractor takes framework-native `req`/`res`, so adapters wrap it in a framework-free thunk before handing it to the core.
+
+### Locale propagation
+Merging the `X-DC-Locale` request header into the security context via `resolveRequestLocale` + `withLocaleInSecurityContext`. Historically a copy-pasted `extractSecurityContextWithLocale` wrapper per adapter; the handler protocol moves locale-merge **into the core** (reading the header through `HttpPort.getHeader`), deleting the wrapper as endpoints migrate.
+
+### MCP transport
+The JSON-RPC 2.0 protocol layer (`mcp-transport.ts`) shared by all adapters: `dispatchMcpMethod`, protocol negotiation, origin validation, SSE serialization. SSE support enters the HttpPort in #909 as an **optional** member / `SseCapablePort` extension — never a new required member, since the port is public.


### PR DESCRIPTION
Adds the per-repo configuration the engineering skills (`to-issues`, `triage`, `to-prd`, `qa`, `improve-codebase-architecture`, `diagnosing-bugs`, `tdd`) expect, plus the first domain glossary.

## What's included
- **`CLAUDE.md`** — new "Agent skills" section pointing at the issue-tracker, triage-label, and domain-docs configuration.
- **`docs/agents/`**
  - `issue-tracker.md` — issues live as GitHub issues in `cliftonc/drizzle-cube`, managed via the `gh` CLI.
  - `triage-labels.md` — the five canonical triage roles → this repo's label strings.
  - `domain.md` — how skills consume the multi-context domain docs.
- **`CONTEXT-MAP.md`** — root index of the per-area domain glossaries.
- **`src/adapters/CONTEXT.md`** — adapters/transport ubiquitous language (handler protocol, HttpPort, CubeHttpHandler core, MCP transport, security context, locale propagation), seeded from the issue-906 grilling.

Docs only — no code or behaviour changes; nothing to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
