### PR TITLE
feat(adapters): handler-protocol seam + CubeHttpHandler core, Express /load migrated (#906)

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,16 @@
         "default": "./dist/adapters/nextjs/index.cjs"
       }
     },
+    "./adapters/core": {
+      "import": {
+        "types": "./dist/adapters/core/index.d.ts",
+        "default": "./dist/adapters/core/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/adapters/core/index.d.ts",
+        "default": "./dist/adapters/core/index.cjs"
+      }
+    },
     "./adapters/utils": {
       "import": {
         "types": "./dist/adapters/utils.d.ts",

--- a/src/adapters/CLAUDE.md
+++ b/src/adapters/CLAUDE.md
@@ -12,6 +12,7 @@ HTTP + MCP adapter layer: maps Cube.js-compatible endpoints onto Express, Fastif
 | express/index.ts | `ExpressAdapterOptions`, `createCubeRouter`, `mountCubeRoutes`, `createCubeApp` | Express router/app factory |
 | fastify/index.ts | `FastifyAdapterOptions`, `cubePlugin`, `registerCubeRoutes`, `createCubeApp` | Fastify plugin + app factory |
 | hono/index.ts | `HonoAdapterOptions`, `createCubeRoutes`, `mountCubeRoutes`, `createCubeApp` | Hono routes/app factory |
+| core/index.ts | `HttpPort`, `createCubeHttpHandler`, `CubeHttpHandler`, `CubeHttpHandlerOptions`, `BaseSecurityContextThunk` | Framework-agnostic HTTP handler seam — generic `HttpPort<TRes>` port + deep `createCubeHttpHandler` core (REST `/load` GET+POST). Public so third parties can build adapters for other frameworks. Express `/load` is migrated onto it; others follow. |
 | nextjs/index.ts | `NextAdapterOptions`, `createLoadHandler`, `createMetaHandler`, `createSqlHandler`, `createDryRunHandler`, `createBatchHandler`, `createExplainHandler`, `createDiscoverHandler`, `createSuggestHandler`, `createValidateHandler`, `createMcpRpcHandler`, `createAgentChatHandler`, `createCubeHandlers` | Next.js App Router — individual handler creators (not a router) |
 
 ## API Endpoints

--- a/src/adapters/core/cube-http-handler.ts
+++ b/src/adapters/core/cube-http-handler.ts
@@ -1,0 +1,117 @@
+/**
+ * Framework-agnostic core for the REST `/load` endpoint.
+ *
+ * This is the deep module behind the framework adapters: it runs the full REST
+ * load orchestration against an {@link HttpPort}, with no framework types inside.
+ *
+ * NOTE: This is a DIFFERENT load orchestration from `handleLoad` in
+ * `src/server/query-handlers.ts`. That one is the MCP/agent-flavored load
+ * (normalizes AI fields, throws on invalid, no cache control, returns raw
+ * `{ data, annotation, query }`). This REST load does NOT normalize, maps
+ * validation failures to 400 JSON, honors `x-cache-control: no-cache`, and
+ * returns `formatCubeResponse(...)`. The two coexist by design; converging them
+ * is a separate, later decision.
+ */
+
+import type { SemanticLayerCompiler } from '../../server/compiler.js'
+import type { SemanticQuery, SecurityContext } from '../../server/index.js'
+import { formatCubeResponse, formatErrorResponse } from '../utils.js'
+import { resolveRequestLocale, withLocaleInSecurityContext } from '../locale.js'
+import type { HttpPort } from './http-port.js'
+
+/** Returns the base (pre-locale) security context for a request. */
+export type BaseSecurityContextThunk = () => SecurityContext | Promise<SecurityContext>
+
+export interface CubeHttpHandlerOptions {
+  /** The semantic layer the load flow validates and executes against. */
+  semanticLayer: SemanticLayerCompiler
+  /** Called once in the catch-all 500 path with the thrown error (e.g. for logging). */
+  onError: (error: unknown) => void
+}
+
+export interface CubeHttpHandler {
+  handleLoadGet<TRes>(port: HttpPort<TRes>, getBaseSecurityContext: BaseSecurityContextThunk): Promise<TRes>
+  handleLoadPost<TRes>(port: HttpPort<TRes>, getBaseSecurityContext: BaseSecurityContextThunk): Promise<TRes>
+}
+
+/**
+ * Build the REST `/load` handlers (GET + POST) once. Each entry point owns its
+ * own request extraction, then funnels into the shared `runLoad` tail.
+ */
+export function createCubeHttpHandler(options: CubeHttpHandlerOptions): CubeHttpHandler {
+  const { semanticLayer, onError } = options
+
+  /** Map an unexpected (thrown) error to a 500, logging it via the injected onError. */
+  function handleCatchAll<TRes>(error: unknown, port: HttpPort<TRes>): TRes {
+    onError(error)
+    return port.send(500, formatErrorResponse(
+      error instanceof Error ? error.message : 'Query execution failed',
+      500
+    ))
+  }
+
+  async function runLoad<TRes>(
+    query: SemanticQuery,
+    port: HttpPort<TRes>,
+    getBaseSecurityContext: BaseSecurityContextThunk
+  ): Promise<TRes> {
+    // Merge the request locale into the (pre-locale) security context here in the core.
+    const requestLocale = resolveRequestLocale((name) => port.getHeader(name))
+    const securityContext = withLocaleInSecurityContext(await getBaseSecurityContext(), requestLocale)
+
+    const validation = semanticLayer.validateQuery(query)
+    if (!validation.isValid) {
+      return port.send(400, formatErrorResponse(
+        `Query validation failed: ${validation.errors.join(', ')}`,
+        400
+      ))
+    }
+
+    const skipCache = port.getHeader('x-cache-control') === 'no-cache'
+
+    const result = await semanticLayer.executeMultiCubeQuery(query, securityContext, { skipCache })
+    return port.send(200, formatCubeResponse(query, result, semanticLayer))
+  }
+
+  async function handleLoadPost<TRes>(
+    port: HttpPort<TRes>,
+    getBaseSecurityContext: BaseSecurityContextThunk
+  ): Promise<TRes> {
+    try {
+      const body = await port.getBody()
+      // Accept both the nested `{ query }` and the bare-query body shapes
+      // (mirrors the adapters' original `req.body.query || req.body`).
+      const query = ((body as { query?: SemanticQuery })?.query || body) as SemanticQuery
+      return await runLoad(query, port, getBaseSecurityContext)
+    } catch (error) {
+      return handleCatchAll(error, port)
+    }
+  }
+
+  async function handleLoadGet<TRes>(
+    port: HttpPort<TRes>,
+    getBaseSecurityContext: BaseSecurityContextThunk
+  ): Promise<TRes> {
+    try {
+      // GET-specific extraction: param presence + JSON parse are explicit 400s,
+      // checked before any security-context resolution.
+      const queryParam = port.getQueryParam('query')
+      if (!queryParam) {
+        return port.send(400, formatErrorResponse('Query parameter is required', 400))
+      }
+
+      let query: SemanticQuery
+      try {
+        query = JSON.parse(queryParam)
+      } catch {
+        return port.send(400, formatErrorResponse('Invalid JSON in query parameter', 400))
+      }
+
+      return await runLoad(query, port, getBaseSecurityContext)
+    } catch (error) {
+      return handleCatchAll(error, port)
+    }
+  }
+
+  return { handleLoadGet, handleLoadPost }
+}

--- a/src/adapters/core/http-port.ts
+++ b/src/adapters/core/http-port.ts
@@ -1,0 +1,22 @@
+/**
+ * Framework port for the HTTP handler core.
+ *
+ * Captures the minimal transport surface a handler needs, generically over the
+ * framework's response type `TRes` so the same core works for adapters that
+ * mutate a response object (Express) and adapters that return a `Response`
+ * (Hono/Next.js). Implementations are constructed per request by each adapter.
+ *
+ * This interface is public — third parties implement it to build adapters for
+ * other frameworks. Add new capabilities as optional members or via a separate
+ * extension interface; a new required member is a breaking change.
+ */
+export interface HttpPort<TRes> {
+  /** Read a request header by (case-insensitive) name. Synchronous. */
+  getHeader(name: string): string | undefined
+  /** Resolve the parsed request body. Async (Express resolves `req.body`; others await `.json()`). */
+  getBody(): Promise<unknown>
+  /** Read a raw query-string value by name (used by GET). */
+  getQueryParam(name: string): string | undefined
+  /** Send a response with the given status and JSON body; returns the framework's response value. */
+  send(status: number, body: unknown): TRes
+}

--- a/src/adapters/core/index.ts
+++ b/src/adapters/core/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Public entry point for the framework-agnostic HTTP handler core.
+ *
+ * Third parties can build adapters for other frameworks by implementing
+ * {@link HttpPort} and driving it with {@link createCubeHttpHandler}.
+ */
+export type { HttpPort } from './http-port.js'
+export {
+  createCubeHttpHandler,
+  type CubeHttpHandler,
+  type CubeHttpHandlerOptions,
+  type BaseSecurityContextThunk
+} from './cube-http-handler.js'

--- a/src/adapters/express/index.ts
+++ b/src/adapters/express/index.ts
@@ -23,7 +23,6 @@ import type { MySql2Database } from 'drizzle-orm/mysql2'
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 import {
   handleDryRun,
-  formatCubeResponse,
   formatSqlResponse,
   formatMetaResponse,
   formatErrorResponse,
@@ -50,6 +49,20 @@ import {
   MCP_SESSION_ID_HEADER
 } from '../mcp-transport.js'
 import { ensureLocaleHeader, resolveRequestLocale, withLocaleInSecurityContext } from '../locale.js'
+import { createCubeHttpHandler, type HttpPort } from '../core/index.js'
+
+/**
+ * Construct a framework-agnostic HttpPort over an Express request/response pair.
+ * Drives the REST /load core (see src/adapters/core).
+ */
+function createExpressPort(req: Request, res: Response): HttpPort<Response> {
+  return {
+    getHeader: (name) => req.get(name),
+    getBody: async () => req.body,
+    getQueryParam: (name) => req.query[name] as string | undefined,
+    send: (status, body) => res.status(status).json(body)
+  }
+}
 
 export interface ExpressAdapterOptions {
   /**
@@ -206,99 +219,27 @@ export function createCubeRouter(
     semanticLayer.registerCube(cube)
   })
 
+  // REST /load core (framework-agnostic). The base-context thunk returns the
+  // pre-locale context; the core does the locale merge. Other endpoints below
+  // still use extractSecurityContextWithLocale until they migrate (A2/A3).
+  const httpHandler = createCubeHttpHandler({
+    semanticLayer,
+    // codeql[js/log-injection] error source is internal, not user-controlled
+    onError: (error) => console.error('Query execution error:', error)
+  })
+
   /**
    * POST /cubejs-api/v1/load - Execute queries
    */
   router.post(`${basePath}/load`, async (req: Request, res: Response) => {
-    try {
-      // Handle both direct query and nested query formats
-      const query: SemanticQuery = req.body.query || req.body
-
-      // Extract security context using user-provided function
-      const securityContext = await extractSecurityContextWithLocale(req, res)
-
-      // Validate query structure and field existence
-      const validation = semanticLayer.validateQuery(query)
-      if (!validation.isValid) {
-        return res.status(400).json(formatErrorResponse(
-          `Query validation failed: ${validation.errors.join(', ')}`,
-          400
-        ))
-      }
-
-      // Check for cache bypass header (X-Cache-Control: no-cache)
-      const skipCache = req.headers['x-cache-control'] === 'no-cache'
-
-      // Execute multi-cube query (handles both single and multi-cube automatically)
-      const result = await semanticLayer.executeMultiCubeQuery(query, securityContext, { skipCache })
-
-      // Return in official Cube.js format
-      res.json(formatCubeResponse(query, result, semanticLayer))
-
-    } catch (error) {
-
-      // codeql[js/log-injection] error source is internal, not user-controlled
-      console.error('Query execution error:', error)
-      res.status(500).json(formatErrorResponse(
-        error instanceof Error ? error.message : 'Query execution failed',
-        500
-      ))
-    }
+    await httpHandler.handleLoadPost(createExpressPort(req, res), () => extractSecurityContext(req, res))
   })
 
   /**
    * GET /cubejs-api/v1/load - Execute queries via query string
    */
   router.get(`${basePath}/load`, async (req: Request, res: Response) => {
-    try {
-      const queryParam = req.query.query as string
-      if (!queryParam) {
-        return res.status(400).json(formatErrorResponse(
-          'Query parameter is required',
-          400
-        ))
-      }
-
-      let query: SemanticQuery
-      try {
-        query = JSON.parse(queryParam)
-      } catch {
-        return res.status(400).json(formatErrorResponse(
-          'Invalid JSON in query parameter',
-          400
-        ))
-      }
-
-      // Extract security context
-      const securityContext = await extractSecurityContextWithLocale(req, res)
-
-      // Validate query structure and field existence
-      const validation = semanticLayer.validateQuery(query)
-      if (!validation.isValid) {
-        return res.status(400).json(formatErrorResponse(
-          `Query validation failed: ${validation.errors.join(', ')}`,
-          400
-        ))
-      }
-
-      // Check for cache bypass header (X-Cache-Control: no-cache)
-      const skipCache = req.headers['x-cache-control'] === 'no-cache'
-
-      // Execute multi-cube query (handles both single and multi-cube automatically)
-      const result = await semanticLayer.executeMultiCubeQuery(query, securityContext, { skipCache })
-
-      // Return in official Cube.js format
-      res.json(formatCubeResponse(query, result, semanticLayer))
-
-    } catch (error) {
-
-      // codeql[js/log-injection] error source is internal, not user-controlled
-      console.error('Query execution error:', error)
-      res.status(500).json(formatErrorResponse(
-        error instanceof Error ? error.message : 'Query execution failed',
-        500
-      ))
-    }
+    await httpHandler.handleLoadGet(createExpressPort(req, res), () => extractSecurityContext(req, res))
   })
 
   /**

--- a/tests/adapters/cube-http-handler.test.ts
+++ b/tests/adapters/cube-http-handler.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createCubeHttpHandler } from '../../src/adapters/core'
+import type { HttpPort } from '../../src/adapters/core'
+
+/**
+ * Unit tests for the framework-agnostic REST /load core.
+ * No server, no DB — a stub semanticLayer and a fake port exercise the flow.
+ */
+
+/** Minimal stub of the bits of SemanticLayerCompiler the load core touches. */
+function createStubSemanticLayer(overrides: Record<string, any> = {}) {
+  return {
+    getEngineType: () => 'postgres',
+    validateQuery: vi.fn(() => ({ isValid: true, errors: [] })),
+    executeMultiCubeQuery: vi.fn(async () => ({ data: [{ 'Employees.count': 5 }], annotation: { measures: {} } })),
+    ...overrides
+  } as any
+}
+
+/** Records send() calls and exposes headers/body/query for the handler to read. */
+function createFakePort(opts: {
+  headers?: Record<string, string>
+  body?: unknown
+  queryParams?: Record<string, string>
+} = {}): HttpPort<{ status: number; body: unknown }> & { sent: Array<{ status: number; body: unknown }> } {
+  const sent: Array<{ status: number; body: unknown }> = []
+  return {
+    sent,
+    getHeader: (name: string) => opts.headers?.[name.toLowerCase()],
+    getBody: async () => opts.body,
+    getQueryParam: (name: string) => opts.queryParams?.[name],
+    send: (status: number, body: unknown) => {
+      const result = { status, body }
+      sent.push(result)
+      return result
+    }
+  }
+}
+
+describe('createCubeHttpHandler — REST /load core', () => {
+  const baseSecurityContext = { organisationId: 'org1' }
+  const getBaseSC = async () => baseSecurityContext
+
+  it('POST happy path returns a 200 Cube.js envelope', async () => {
+    const semanticLayer = createStubSemanticLayer()
+    const handler = createCubeHttpHandler({ semanticLayer, onError: vi.fn() })
+    const port = createFakePort({ body: { measures: ['Employees.count'] } })
+
+    await handler.handleLoadPost(port, getBaseSC)
+
+    expect(port.sent).toHaveLength(1)
+    expect(port.sent[0].status).toBe(200)
+    const envelope = port.sent[0].body as any
+    expect(envelope.queryType).toBe('regularQuery')
+    expect(envelope.results[0].data).toEqual([{ 'Employees.count': 5 }])
+  })
+
+  it('POST validation failure returns a 400 without executing', async () => {
+    const semanticLayer = createStubSemanticLayer({
+      validateQuery: vi.fn(() => ({ isValid: false, errors: ['Unknown member Foo.bar'] }))
+    })
+    const handler = createCubeHttpHandler({ semanticLayer, onError: vi.fn() })
+    const port = createFakePort({ body: { measures: ['Foo.bar'] } })
+
+    await handler.handleLoadPost(port, getBaseSC)
+
+    expect(port.sent).toHaveLength(1)
+    expect(port.sent[0].status).toBe(400)
+    expect((port.sent[0].body as any).error).toContain('Query validation failed')
+    expect(semanticLayer.executeMultiCubeQuery).not.toHaveBeenCalled()
+  })
+
+  it('honors x-cache-control: no-cache by passing skipCache: true to the executor', async () => {
+    const semanticLayer = createStubSemanticLayer()
+    const handler = createCubeHttpHandler({ semanticLayer, onError: vi.fn() })
+    const port = createFakePort({
+      body: { measures: ['Employees.count'] },
+      headers: { 'x-cache-control': 'no-cache' }
+    })
+
+    await handler.handleLoadPost(port, getBaseSC)
+
+    expect(semanticLayer.executeMultiCubeQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { skipCache: true }
+    )
+  })
+
+  it('GET happy path parses the query param and returns a 200 envelope', async () => {
+    const semanticLayer = createStubSemanticLayer()
+    const handler = createCubeHttpHandler({ semanticLayer, onError: vi.fn() })
+    const port = createFakePort({
+      queryParams: { query: JSON.stringify({ measures: ['Employees.count'] }) }
+    })
+
+    await handler.handleLoadGet(port, getBaseSC)
+
+    expect(port.sent[0].status).toBe(200)
+    expect(semanticLayer.executeMultiCubeQuery).toHaveBeenCalledWith(
+      { measures: ['Employees.count'] },
+      expect.anything(),
+      expect.anything()
+    )
+  })
+
+  it('GET with missing query param returns 400 "Query parameter is required"', async () => {
+    const semanticLayer = createStubSemanticLayer()
+    const onError = vi.fn()
+    const handler = createCubeHttpHandler({ semanticLayer, onError })
+    const port = createFakePort({ queryParams: {} })
+
+    await handler.handleLoadGet(port, getBaseSC)
+
+    expect(port.sent[0].status).toBe(400)
+    expect((port.sent[0].body as any).error).toBe('Query parameter is required')
+    expect(semanticLayer.executeMultiCubeQuery).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('GET with invalid JSON returns 400 "Invalid JSON in query parameter"', async () => {
+    const semanticLayer = createStubSemanticLayer()
+    const onError = vi.fn()
+    const handler = createCubeHttpHandler({ semanticLayer, onError })
+    const port = createFakePort({ queryParams: { query: '{not valid json' } })
+
+    await handler.handleLoadGet(port, getBaseSC)
+
+    expect(port.sent[0].status).toBe(400)
+    expect((port.sent[0].body as any).error).toBe('Invalid JSON in query parameter')
+    expect(semanticLayer.executeMultiCubeQuery).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('a thrown executor error returns 500 and calls onError exactly once', async () => {
+    const boom = new Error('connection refused')
+    const semanticLayer = createStubSemanticLayer({
+      executeMultiCubeQuery: vi.fn(async () => { throw boom })
+    })
+    const onError = vi.fn()
+    const handler = createCubeHttpHandler({ semanticLayer, onError })
+    const port = createFakePort({ body: { measures: ['Employees.count'] } })
+
+    await handler.handleLoadPost(port, getBaseSC)
+
+    expect(port.sent[0].status).toBe(500)
+    expect((port.sent[0].body as any).error).toBe('connection refused')
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(boom)
+  })
+
+  it('merges the X-DC-Locale header into the security context the executor receives', async () => {
+    const semanticLayer = createStubSemanticLayer()
+    const handler = createCubeHttpHandler({ semanticLayer, onError: vi.fn() })
+    const port = createFakePort({
+      body: { measures: ['Employees.count'] },
+      headers: { 'x-dc-locale': 'nl-NL' }
+    })
+
+    await handler.handleLoadPost(port, getBaseSC)
+
+    const [, securityContext] = semanticLayer.executeMultiCubeQuery.mock.calls[0]
+    expect(securityContext).toMatchObject({ organisationId: 'org1', locale: 'nl-NL' })
+  })
+})

--- a/vite.config.adapters.ts
+++ b/vite.config.adapters.ts
@@ -26,6 +26,7 @@ export default defineConfig({
         'express/index': resolve(__dirname, 'src/adapters/express/index.ts'),
         'fastify/index': resolve(__dirname, 'src/adapters/fastify/index.ts'),
         'nextjs/index': resolve(__dirname, 'src/adapters/nextjs/index.ts'),
+        'core/index': resolve(__dirname, 'src/adapters/core/index.ts'),
         'utils': resolve(__dirname, 'src/adapters/utils.ts'),
         'types': resolve(__dirname, 'src/adapters/types.ts'),
         'mcp-tools': resolve(__dirname, 'src/adapters/mcp-tools.ts')


### PR DESCRIPTION
Closes #906.

## What this does

Introduces the **framework-agnostic handler seam** and proves it end-to-end through Express `/load` only (tracer slice A1 of 3). The four adapters each re-implement the same REST `/load` flow inline; this carves out a reusable core and migrates Express onto it.

- **`src/adapters/core/http-port.ts`** — generic `HttpPort<TRes>` port interface (`getHeader`, `getBody`, `getQueryParam`, `send`) with **no** framework-specific types, generic over the response type so it works for both `res`-mutating (Express) and `Response`-returning (Hono/Next) frameworks.
- **`src/adapters/core/cube-http-handler.ts`** — deep `createCubeHttpHandler({ semanticLayer, onError })` core returning `{ handleLoadGet, handleLoadPost }`. Each entry point owns its own extraction (GET: param → `JSON.parse` → the two 400s; POST: `query || body` unwrap) and try/catch, then funnels into a shared `runLoad` tail: locale-merge → `validateQuery` (→400) → `x-cache-control: no-cache` → `executeMultiCubeQuery({ skipCache })` → `formatCubeResponse` (→200), catch-all 500 calling injected `onError`. A code comment notes the REST load and the MCP `handleLoad` coexist **by design** (convergence deferred).
- **Express `/load`** (GET + POST) rewired onto the core via a local `createExpressPort`. Every other Express endpoint and `extractSecurityContextWithLocale` are untouched. Responses are structurally identical modulo the already-non-deterministic `requestId`/`lastRefreshTime`.
- **Public API:** `./adapters/core` subpath export (CJS-types subdir convention per #881) + `core/index` build entry; `check:exports` green.

## Tests

- 8 new **core unit tests** (`tests/adapters/cube-http-handler.test.ts`) using a stub `semanticLayer` + fake port (no server, no DB): happy 200 envelope, validation 400, `no-cache` → `skipCache: true`, the two GET 400s, executor-throw → `onError` once + 500, and locale merge. Built test-first (RED→GREEN per behavior).
- Existing Express byte-guard + all adapter integration tests pass.

## Gate

- `tests/adapters/` — **320 passed** ✓
- `npm run typecheck` ✓ · `npm run lint` ✓ · `npm run check:exports` ✓ (`drizzle-cube/adapters/core` 🟢 CJS + ESM)

## Out of scope (later slices)

- Rest of Express (meta/sql/dry-run/batch/explain + MCP) → A2 (#908)
- Fastify/Hono/Next.js + deleting the locale wrapper everywhere + SSE on the port → A3 (#909)
- Converging REST `/load` and MCP `handleLoad` → separate decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)