### PR TITLE
feat(logical-plan): extract testable SchemaBuilder from LogicalPlanBuilder (#912)

### DIFF
--- a/src/server/logical-plan/CLAUDE.md
+++ b/src/server/logical-plan/CLAUDE.md
@@ -22,6 +22,7 @@ src/server/logical-plan/
 ├── join-planner.ts             JoinPlanner — join-plan construction
 ├── cte-planner.ts              CTEPlanner — pre-aggregation CTE decisions (fan-out prevention)
 ├── cte-planner-helpers.ts      Pure CTE join-key derivation / join-def resolution for CTEPlanner
+├── schema-builder.ts           Pure (query, cubes) => LogicalSchema derivation (measure/dimension/time refs)
 ├── filter-propagation.ts       FilterPropagation — filter propagation into CTEs
 ├── plan-analysis-reporter.ts   PlanAnalysisReporter — dry-run/EXPLAIN trace + warnings
 ├── planner-utils.ts            ResolverCache + shared cube-usage helpers
@@ -35,6 +36,7 @@ src/server/logical-plan/
 |-----------|----------|---------|
 | `LogicalPlanBuilder` | `logical-plan-builder.ts` | Builds `LogicalNode` tree from semantic query; produces `LogicalPlanWithAnalysis` (plan + trace) |
 | `LogicalPlanner` | `logical-planner.ts` | Facade composing the planning phases: cube usage, primary cube selection, join path resolution, CTE decisions |
+| `buildLogicalSchema` | `schema-builder.ts` | Pure `(query, cubes) => LogicalSchema` derivation; consumed by `LogicalPlanBuilder` (unit-testable without a planner) |
 | `JoinPlanner` | `join-planner.ts` | Builds the join plan (path resolution, belongsToMany expansion) |
 | `CTEPlanner` | `cte-planner.ts` | Decides pre-aggregation CTEs to prevent fan-out; multi-hop absorption |
 | `FilterPropagation` | `filter-propagation.ts` | Propagates related-cube filters into CTEs |

--- a/src/server/logical-plan/logical-plan-builder.ts
+++ b/src/server/logical-plan/logical-plan-builder.ts
@@ -20,6 +20,14 @@ import type { LogicalPlanner } from './logical-planner.js'
 import { hasPostAggregationWindows } from '../measure-classification.js'
 import { resolveCubeReference } from '../cube-utils.js'
 import { t } from '../../i18n/runtime.js'
+import {
+  buildMeasureRefs,
+  buildDimensionRefs,
+  buildTimeDimensionRefs,
+  buildLogicalSchema,
+  buildCTESchema,
+  toCubeRef
+} from './schema-builder.js'
 import type {
   LogicalNode,
   QueryNode,
@@ -28,10 +36,7 @@ import type {
   KeysDeduplication,
   MultiFactMerge,
   MeasureRef,
-  DimensionRef,
-  TimeDimensionRef,
   OrderByRef,
-  CubeRef,
   JoinRef,
   LogicalSchema,
   ColumnRef
@@ -239,7 +244,7 @@ export class LogicalPlanBuilder {
   ): SourceBuildResult {
     const multiFactSource = this.tryBuildMultiFactMergeSource(query, cubes, ctx)
     if (multiFactSource) {
-      const measures = this.buildMeasureRefs(query, cubes)
+      const measures = buildMeasureRefs(query, cubes)
       const classification: MeasureClassification = {
         regular: measures,
         multiplied: [],
@@ -288,21 +293,17 @@ export class LogicalPlanBuilder {
     cubes: Map<string, Cube>,
     query: SemanticQuery
   ): SimpleSource {
-    const measures = this.buildMeasureRefs(query, cubes)
-    const dimensions = this.buildDimensionRefs(query, cubes)
-    const timeDimensions = this.buildTimeDimensionRefs(query, cubes)
-
-    const primaryCubeRef = this.toCubeRef(primaryCube)
+    const primaryCubeRef = toCubeRef(primaryCube)
 
     // Join cubes are already symbolic JoinRefs (emitted by JoinPlanner).
     const joins: JoinRef[] = joinCubes
 
     // Convert pre-aggregation CTEs
     const ctes: CTEPreAggregate[] = preAggregationCTEs.map(cteInfo => {
-      const cubeRef = this.toCubeRef(cteInfo.cube)
+      const cubeRef = toCubeRef(cteInfo.cube)
       return {
         type: 'ctePreAggregate' as const,
-        schema: this.buildCTESchema(cteInfo, cubes),
+        schema: buildCTESchema(cteInfo, cubes),
         cube: cubeRef,
         alias: cteInfo.alias,
         cteAlias: cteInfo.cteAlias,
@@ -317,7 +318,7 @@ export class LogicalPlanBuilder {
     })
 
     // Build source schema
-    const schema: LogicalSchema = { measures, dimensions, timeDimensions }
+    const schema: LogicalSchema = buildLogicalSchema(query, cubes)
 
     return {
       type: 'simpleSource',
@@ -384,10 +385,10 @@ export class LogicalPlanBuilder {
       return null
     }
 
-    const sharedDimensions = this.buildDimensionRefs(query, cubes)
-    const sharedTimeDimensions = this.buildTimeDimensionRefs(query, cubes)
+    const sharedDimensions = buildDimensionRefs(query, cubes)
+    const sharedTimeDimensions = buildTimeDimensionRefs(query, cubes)
     const schema: LogicalSchema = {
-      measures: this.buildMeasureRefs(query, cubes),
+      measures: buildMeasureRefs(query, cubes),
       dimensions: sharedDimensions,
       timeDimensions: sharedTimeDimensions
     }
@@ -755,17 +756,10 @@ export class LogicalPlanBuilder {
     cubes: Map<string, Cube>,
     warnings: QueryWarning[]
   ): QueryNode {
-    const measures = this.buildMeasureRefs(query, cubes)
-    const dimensions = this.buildDimensionRefs(query, cubes)
-    const timeDimensions = this.buildTimeDimensionRefs(query, cubes)
+    const schema: LogicalSchema = buildLogicalSchema(query, cubes)
+    const { measures, dimensions, timeDimensions } = schema
     const orderBy = this.buildOrderByRefs(query)
     const filters = query.filters ?? []
-
-    const schema: LogicalSchema = {
-      measures,
-      dimensions,
-      timeDimensions
-    }
 
     return {
       type: 'query',
@@ -807,55 +801,6 @@ export class LogicalPlanBuilder {
   // Reference builders
   // ---------------------------------------------------------------------------
 
-  private buildMeasureRefs(query: SemanticQuery, cubes: Map<string, Cube>): MeasureRef[] {
-    if (!query.measures) return []
-
-    return query.measures.map(name => {
-      const [cubeName, localName] = name.split('.')
-      const cube = cubes.get(cubeName)
-      if (!cube) throw new Error(t('server.errors.cubeNotFoundForMeasure', { cubeName, measure: name }))
-      return {
-        name,
-        cube: this.toCubeRef(cube),
-        localName
-      }
-    })
-  }
-
-  private buildDimensionRefs(query: SemanticQuery, cubes: Map<string, Cube>): DimensionRef[] {
-    if (!query.dimensions) return []
-
-    return query.dimensions.map(name => {
-      const [cubeName, localName] = name.split('.')
-      const cube = cubes.get(cubeName)
-      if (!cube) throw new Error(t('server.errors.cubeNotFoundForDimension', { cubeName, dimension: name }))
-      return {
-        name,
-        cube: this.toCubeRef(cube),
-        localName
-      }
-    })
-  }
-
-  private buildTimeDimensionRefs(query: SemanticQuery, cubes: Map<string, Cube>): TimeDimensionRef[] {
-    if (!query.timeDimensions) return []
-
-    return query.timeDimensions.map(td => {
-      const [cubeName, localName] = td.dimension.split('.')
-      const cube = cubes.get(cubeName)
-      if (!cube) throw new Error(t('server.errors.cubeNotFoundForTimeDimension', { cubeName, timeDimension: td.dimension }))
-      return {
-        name: td.dimension,
-        cube: this.toCubeRef(cube),
-        localName,
-        granularity: td.granularity,
-        dateRange: td.dateRange,
-        fillMissingDates: td.fillMissingDates,
-        compareDateRange: td.compareDateRange
-      }
-    })
-  }
-
   private buildOrderByRefs(query: SemanticQuery): OrderByRef[] {
     if (!query.order) return []
 
@@ -865,32 +810,4 @@ export class LogicalPlanBuilder {
     }))
   }
 
-  // ---------------------------------------------------------------------------
-  // Helpers
-  // ---------------------------------------------------------------------------
-
-  private toCubeRef(cube: Cube): CubeRef {
-    return { name: cube.name, cube }
-  }
-
-  private buildCTESchema(
-    cteInfo: NonNullable<PhysicalQueryPlan['preAggregationCTEs']>[number],
-    cubes: Map<string, Cube>
-  ): LogicalSchema {
-    const measures: MeasureRef[] = cteInfo.measures.map(name => {
-      const [cubeName, localName] = name.split('.')
-      const cube = cubes.get(cubeName)
-      return {
-        name,
-        cube: { name: cubeName, cube: cube! },
-        localName
-      }
-    })
-
-    return {
-      measures,
-      dimensions: [],
-      timeDimensions: []
-    }
-  }
 }

--- a/src/server/logical-plan/schema-builder.ts
+++ b/src/server/logical-plan/schema-builder.ts
@@ -1,0 +1,112 @@
+/**
+ * Schema derivation — pure functions that turn a SemanticQuery (or a
+ * pre-aggregation CTE descriptor) plus the resolved cube registry into a
+ * LogicalSchema (measures, dimensions, time dimensions).
+ *
+ * Extracted from LogicalPlanBuilder so schema correctness is verifiable in
+ * isolation, with no LogicalPlanner / QueryContext setup. Mirrors the repo's
+ * other pure derivation modules (cte-planner-helpers, compiler-metadata,
+ * measure-classification).
+ */
+import type { Cube, PhysicalQueryPlan } from '../types/index.js'
+import type { SemanticQuery } from '../types/query.js'
+import { t } from '../../i18n/runtime.js'
+import type {
+  CubeRef,
+  MeasureRef,
+  DimensionRef,
+  TimeDimensionRef,
+  LogicalSchema
+} from './types.js'
+
+export function toCubeRef(cube: Cube): CubeRef {
+  return { name: cube.name, cube }
+}
+
+export function buildMeasureRefs(query: SemanticQuery, cubes: Map<string, Cube>): MeasureRef[] {
+  if (!query.measures) return []
+
+  return query.measures.map(name => {
+    const [cubeName, localName] = name.split('.')
+    const cube = cubes.get(cubeName)
+    if (!cube) throw new Error(t('server.errors.cubeNotFoundForMeasure', { cubeName, measure: name }))
+    return {
+      name,
+      cube: toCubeRef(cube),
+      localName
+    }
+  })
+}
+
+export function buildDimensionRefs(query: SemanticQuery, cubes: Map<string, Cube>): DimensionRef[] {
+  if (!query.dimensions) return []
+
+  return query.dimensions.map(name => {
+    const [cubeName, localName] = name.split('.')
+    const cube = cubes.get(cubeName)
+    if (!cube) throw new Error(t('server.errors.cubeNotFoundForDimension', { cubeName, dimension: name }))
+    return {
+      name,
+      cube: toCubeRef(cube),
+      localName
+    }
+  })
+}
+
+export function buildTimeDimensionRefs(query: SemanticQuery, cubes: Map<string, Cube>): TimeDimensionRef[] {
+  if (!query.timeDimensions) return []
+
+  return query.timeDimensions.map(td => {
+    const [cubeName, localName] = td.dimension.split('.')
+    const cube = cubes.get(cubeName)
+    if (!cube) throw new Error(t('server.errors.cubeNotFoundForTimeDimension', { cubeName, timeDimension: td.dimension }))
+    return {
+      name: td.dimension,
+      cube: toCubeRef(cube),
+      localName,
+      granularity: td.granularity,
+      dateRange: td.dateRange,
+      fillMissingDates: td.fillMissingDates,
+      compareDateRange: td.compareDateRange
+    }
+  })
+}
+
+/**
+ * Compose the full logical schema (measures, dimensions, time dimensions) for a
+ * query. This is the primary public interface: `(query, cubes) => LogicalSchema`.
+ */
+export function buildLogicalSchema(query: SemanticQuery, cubes: Map<string, Cube>): LogicalSchema {
+  return {
+    measures: buildMeasureRefs(query, cubes),
+    dimensions: buildDimensionRefs(query, cubes),
+    timeDimensions: buildTimeDimensionRefs(query, cubes)
+  }
+}
+
+/**
+ * Derive the measures-only schema for a pre-aggregation CTE. Unlike the
+ * query-driven builders above, this intentionally does NOT throw on a missing
+ * cube (the cube is guaranteed present by the planner that produced the CTE
+ * descriptor) — preserving exact prior behavior keeps generated SQL unchanged.
+ */
+export function buildCTESchema(
+  cteInfo: NonNullable<PhysicalQueryPlan['preAggregationCTEs']>[number],
+  cubes: Map<string, Cube>
+): LogicalSchema {
+  const measures: MeasureRef[] = cteInfo.measures.map(name => {
+    const [cubeName, localName] = name.split('.')
+    const cube = cubes.get(cubeName)
+    return {
+      name,
+      cube: { name: cubeName, cube: cube! },
+      localName
+    }
+  })
+
+  return {
+    measures,
+    dimensions: [],
+    timeDimensions: []
+  }
+}

--- a/tests/schema-builder.unit.test.ts
+++ b/tests/schema-builder.unit.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toCubeRef,
+  buildMeasureRefs,
+  buildDimensionRefs,
+  buildTimeDimensionRefs,
+  buildLogicalSchema,
+  buildCTESchema
+} from '../src/server/logical-plan/schema-builder'
+import type { Cube, SemanticQuery } from '../src/server/types'
+
+/**
+ * These tests exercise schema derivation in complete isolation — no
+ * LogicalPlanner, no QueryContext, no database. Cubes are minimal in-memory
+ * fixtures; the derivers only need the cube to exist in the registry and the
+ * member name to split on '.'.
+ */
+function createCube(name: string): Cube {
+  return {
+    name,
+    sql: () => ({ from: {} as any }),
+    dimensions: {
+      id: { name: 'id', type: 'number', sql: {} as any, primaryKey: true }
+    },
+    measures: {
+      count: { name: 'count', type: 'count', sql: {} as any }
+    }
+  }
+}
+
+function createCubes(...names: string[]): Map<string, Cube> {
+  return new Map(names.map(name => [name, createCube(name)]))
+}
+
+describe('schema-builder', () => {
+  describe('toCubeRef', () => {
+    it('wraps a cube into a CubeRef', () => {
+      const cube = createCube('Employees')
+      expect(toCubeRef(cube)).toEqual({ name: 'Employees', cube })
+    })
+  })
+
+  describe('buildMeasureRefs', () => {
+    it('derives measure refs with split name, localName and cube ref', () => {
+      const cubes = createCubes('Employees')
+      const query: SemanticQuery = { measures: ['Employees.count'] }
+
+      const refs = buildMeasureRefs(query, cubes)
+
+      expect(refs).toHaveLength(1)
+      expect(refs[0]).toMatchObject({
+        name: 'Employees.count',
+        localName: 'count'
+      })
+      expect(refs[0].cube).toEqual({ name: 'Employees', cube: cubes.get('Employees') })
+    })
+
+    it('returns [] when query has no measures', () => {
+      expect(buildMeasureRefs({}, createCubes('Employees'))).toEqual([])
+    })
+
+    it('throws when the referenced cube is missing', () => {
+      const query: SemanticQuery = { measures: ['Unknown.count'] }
+      expect(() => buildMeasureRefs(query, createCubes('Employees'))).toThrow(/Unknown/)
+    })
+  })
+
+  describe('buildDimensionRefs', () => {
+    it('derives dimension refs', () => {
+      const cubes = createCubes('Employees')
+      const query: SemanticQuery = { dimensions: ['Employees.id'] }
+
+      const refs = buildDimensionRefs(query, cubes)
+
+      expect(refs).toHaveLength(1)
+      expect(refs[0]).toMatchObject({ name: 'Employees.id', localName: 'id' })
+      expect(refs[0].cube.name).toBe('Employees')
+    })
+
+    it('returns [] when query has no dimensions', () => {
+      expect(buildDimensionRefs({}, createCubes('Employees'))).toEqual([])
+    })
+
+    it('throws when the referenced cube is missing', () => {
+      const query: SemanticQuery = { dimensions: ['Unknown.id'] }
+      expect(() => buildDimensionRefs(query, createCubes('Employees'))).toThrow(/Unknown/)
+    })
+  })
+
+  describe('buildTimeDimensionRefs', () => {
+    it('carries granularity, dateRange, fillMissingDates and compareDateRange through', () => {
+      const cubes = createCubes('Employees')
+      const query: SemanticQuery = {
+        timeDimensions: [
+          {
+            dimension: 'Employees.createdAt',
+            granularity: 'month',
+            dateRange: ['2024-01-01', '2024-12-31'],
+            fillMissingDates: true,
+            compareDateRange: [['2023-01-01', '2023-12-31']]
+          }
+        ]
+      }
+
+      const refs = buildTimeDimensionRefs(query, cubes)
+
+      expect(refs).toHaveLength(1)
+      expect(refs[0]).toMatchObject({
+        name: 'Employees.createdAt',
+        localName: 'createdAt',
+        granularity: 'month',
+        dateRange: ['2024-01-01', '2024-12-31'],
+        fillMissingDates: true,
+        compareDateRange: [['2023-01-01', '2023-12-31']]
+      })
+      expect(refs[0].cube.name).toBe('Employees')
+    })
+
+    it('returns [] when query has no timeDimensions', () => {
+      expect(buildTimeDimensionRefs({}, createCubes('Employees'))).toEqual([])
+    })
+
+    it('throws when the referenced cube is missing', () => {
+      const query: SemanticQuery = {
+        timeDimensions: [{ dimension: 'Unknown.createdAt', granularity: 'day' }]
+      }
+      expect(() => buildTimeDimensionRefs(query, createCubes('Employees'))).toThrow(/Unknown/)
+    })
+  })
+
+  describe('buildLogicalSchema', () => {
+    it('composes measures, dimensions and timeDimensions', () => {
+      const cubes = createCubes('Employees', 'Departments')
+      const query: SemanticQuery = {
+        measures: ['Employees.count'],
+        dimensions: ['Departments.id'],
+        timeDimensions: [{ dimension: 'Employees.createdAt', granularity: 'day' }]
+      }
+
+      const schema = buildLogicalSchema(query, cubes)
+
+      expect(schema.measures.map(m => m.name)).toEqual(['Employees.count'])
+      expect(schema.dimensions.map(d => d.name)).toEqual(['Departments.id'])
+      expect(schema.timeDimensions.map(t => t.name)).toEqual(['Employees.createdAt'])
+    })
+
+    it('returns empty arrays for an empty query', () => {
+      expect(buildLogicalSchema({}, createCubes('Employees'))).toEqual({
+        measures: [],
+        dimensions: [],
+        timeDimensions: []
+      })
+    })
+  })
+
+  describe('buildCTESchema', () => {
+    it('derives a measures-only schema', () => {
+      const cubes = createCubes('Employees')
+      const cteInfo = { measures: ['Employees.count'] } as any
+
+      const schema = buildCTESchema(cteInfo, cubes)
+
+      expect(schema.dimensions).toEqual([])
+      expect(schema.timeDimensions).toEqual([])
+      expect(schema.measures).toHaveLength(1)
+      expect(schema.measures[0]).toMatchObject({ name: 'Employees.count', localName: 'count' })
+      expect(schema.measures[0].cube.name).toBe('Employees')
+    })
+
+    it('does NOT throw on a missing cube (preserved prior behavior)', () => {
+      const cteInfo = { measures: ['Unknown.count'] } as any
+      const schema = buildCTESchema(cteInfo, createCubes('Employees'))
+      expect(schema.measures[0]).toMatchObject({ name: 'Unknown.count', localName: 'count' })
+      expect(schema.measures[0].cube).toEqual({ name: 'Unknown', cube: undefined })
+    })
+  })
+})


### PR DESCRIPTION
Closes #912.

## What

Lift schema derivation — turning a `SemanticQuery` + cube registry into a `LogicalSchema` (measures, dimensions, time dimensions) — out of `LogicalPlanBuilder`'s private methods into a new pure free-function module. Schema correctness becomes verifiable in isolation, with **no** `LogicalPlanner` / `QueryContext` setup.

This mirrors the repo's established convention for pure derivation helpers (`cte-planner-helpers.ts`, `compiler-metadata.ts`, `measure-classification.ts`) — free-function modules, no classes.

## Changes

- **New `src/server/logical-plan/schema-builder.ts`**
  - `buildLogicalSchema(query, cubes) => LogicalSchema` — the headline interface
  - `buildMeasureRefs` / `buildDimensionRefs` / `buildTimeDimensionRefs` — granular derivers (still needed by the measures-only and shared-dimension call sites)
  - `buildCTESchema` — measures-only CTE schema; **exact prior behavior preserved** (non-throwing `cube!` assertion) so generated SQL is unchanged
  - `toCubeRef` — single source of truth, imported back by the builder
- **`logical-plan-builder.ts`** — removed the 5 private methods, delegates to the new module, pruned now-unused type imports
- **`tests/schema-builder.unit.test.ts`** — 14 DB-free unit tests with in-memory cube fixtures
- **`logical-plan/CLAUDE.md`** — documented the new module

## Acceptance criteria

- [x] `SchemaBuilder` with `(query, cubes) => LogicalSchema` interface
- [x] `LogicalPlanBuilder` delegates; private methods removed
- [x] Direct unit tests with no `LogicalPlanner` / `QueryContext`
- [x] Generated SQL unchanged across engines — **2385/2385** postgres tests pass
- [x] `npm run test:postgres`, `npm run typecheck`, `npm run lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)