### PR TITLE
fix(nextjs): share one SemanticLayerCompiler across all route handlers (#907)

### DIFF
--- a/src/adapters/CLAUDE.md
+++ b/src/adapters/CLAUDE.md
@@ -56,7 +56,7 @@ All framework option interfaces extend the same shape:
 
 ## Structural Difference: Next.js
 
-Express, Fastify, and Hono export **router/app creators** (`createCubeRouter`, `cubePlugin`, `createCubeRoutes`) that mount all endpoints at once. Next.js instead exports **individual handler creators** (`createLoadHandler`, `createMcpRpcHandler`, etc.) designed for App Router route files — each route file re-exports the relevant handler as `GET`/`POST`/`DELETE`. A convenience `createCubeHandlers` returns all handlers as a single object.
+Express, Fastify, and Hono export **router/app creators** (`createCubeRouter`, `cubePlugin`, `createCubeRoutes`) that mount all endpoints at once. Next.js instead exports **individual handler creators** (`createLoadHandler`, `createMcpRpcHandler`, etc.) designed for App Router route files — each route file re-exports the relevant handler as `GET`/`POST`/`DELETE`. A convenience `createCubeHandlers` returns all handlers as a single object; it builds one `SemanticLayerCompiler` and injects it (via the `semanticLayer` option) into every handler, so they share one metadata/result cache. Standalone single-handler factories still build their own compiler.
 
 ## MCP Transport (mcp-transport.ts)
 

--- a/src/adapters/nextjs/index.ts
+++ b/src/adapters/nextjs/index.ts
@@ -163,6 +163,16 @@ export interface NextAdapterOptions {
    * to configure RLS (e.g., set JWT claims and switch Postgres roles), then runs the query.
    */
   rlsSetup?: RLSSetupFn
+
+  /**
+   * Pre-built semantic layer to reuse across handlers.
+   * When provided, the adapter reuses this compiler instead of constructing a
+   * new one (and skips cube registration — register cubes on it yourself).
+   * `createCubeHandlers` sets this internally so every handler it returns shares
+   * one compiler, keeping metadata/result caches consistent. Mirrors the Hono
+   * adapter's `semanticLayer` option.
+   */
+  semanticLayer?: SemanticLayerCompiler
 }
 
 export interface RouteContext {
@@ -191,6 +201,12 @@ export interface CubeHandlers {
 function createSemanticLayer(
   options: NextAdapterOptions
 ): SemanticLayerCompiler {
+  // Reuse a pre-built compiler when one is injected (e.g. by createCubeHandlers)
+  // so all handlers share a single metadata/result cache.
+  if (options.semanticLayer) {
+    return options.semanticLayer
+  }
+
   const { cubes, drizzle, schema, engineType, cache, rlsSetup } = options
 
   // Validate required options
@@ -873,23 +889,28 @@ export function createCubeHandlers(
 ): CubeHandlers {
   const { mcp = { enabled: true } } = options
 
+  // Build the semantic layer once and inject it into every handler so they all
+  // share one metadata/result cache (cube registration runs a single time).
+  const semanticLayer = createSemanticLayer(options)
+  const sharedOptions: NextAdapterOptions = { ...options, semanticLayer }
+
   const handlers: CubeHandlers = {
-    load: createLoadHandler(options),
-    meta: createMetaHandler(options),
-    sql: createSqlHandler(options),
-    dryRun: createDryRunHandler(options),
-    batch: createBatchHandler(options),
-    explain: createExplainHandler(options)
+    load: createLoadHandler(sharedOptions),
+    meta: createMetaHandler(sharedOptions),
+    sql: createSqlHandler(sharedOptions),
+    dryRun: createDryRunHandler(sharedOptions),
+    batch: createBatchHandler(sharedOptions),
+    explain: createExplainHandler(sharedOptions)
   }
 
   // Add MCP handlers if enabled
   if (mcp.enabled !== false) {
-    handlers.mcpRpc = createMcpRpcHandler(options)
+    handlers.mcpRpc = createMcpRpcHandler(sharedOptions)
   }
 
   // Add agent handler if configured
   if (options.agent) {
-    handlers.agentChat = createAgentChatHandler(options)
+    handlers.agentChat = createAgentChatHandler(sharedOptions)
   }
 
   return handlers

--- a/tests/adapters/nextjs.test.ts
+++ b/tests/adapters/nextjs.test.ts
@@ -46,6 +46,7 @@ import {
 } from '../helpers/test-database'
 import { testSecurityContexts } from '../helpers/enhanced-test-data'
 import { createTestCubesForCurrentDatabase } from '../helpers/test-cubes'
+import { SemanticLayerCompiler } from '../../src/server'
 
 // Mock Next.js environment
 const mockNextUrl = {
@@ -731,6 +732,52 @@ describe('Next.js Adapter', () => {
 
       const data = await response.json() as any
       expect(data.error).toContain('empty')
+    })
+  })
+
+  describe('shared SemanticLayerCompiler (issue #907)', () => {
+    it('backs every createCubeHandlers handler with a single compiler, registering cubes once', () => {
+      const spy = vi.spyOn(SemanticLayerCompiler.prototype, 'registerCube')
+      try {
+        createCubeHandlers(adapterOptions)
+
+        // Cube registration runs once, not once per handler.
+        expect(spy.mock.calls.length).toBe(adapterOptions.cubes.length)
+        // All registrations target one and the same compiler instance.
+        expect(new Set(spy.mock.contexts).size).toBe(1)
+      } finally {
+        spy.mockRestore()
+      }
+    })
+
+    it('keeps standalone single-handler factories independent (each builds its own compiler)', () => {
+      const spy = vi.spyOn(SemanticLayerCompiler.prototype, 'registerCube')
+      try {
+        createLoadHandler(adapterOptions)
+        createMetaHandler(adapterOptions)
+
+        // Two separate standalone factory calls => two distinct compilers.
+        expect(new Set(spy.mock.contexts).size).toBe(2)
+      } finally {
+        spy.mockRestore()
+      }
+    })
+
+    it('returns working load and meta handlers backed by the shared compiler', async () => {
+      skipIfDuckDB()
+      const handlers = createCubeHandlers(adapterOptions)
+
+      const loadResponse = await handlers.load(
+        createMockNextRequest('POST', { measures: ['Employees.count'] })
+      )
+      expect(loadResponse.status).toBe(200)
+      const loadData = await loadResponse.json() as any
+      expect(Array.isArray(loadData.results)).toBe(true)
+
+      const metaResponse = await handlers.meta(createMockNextRequest('GET'))
+      expect(metaResponse.status).toBe(200)
+      const metaData = await metaResponse.json() as any
+      expect(metaData.cubes.some((c: any) => c.name === 'Employees')).toBe(true)
     })
   })
 })


### PR DESCRIPTION
Closes #907.

## Problem

The Next.js adapter created a **fresh `SemanticLayerCompiler` per endpoint**: every `create*Handler(options)` calls `createSemanticLayer(options)` internally, and `createCubeHandlers` wires 7+ of them. The result was 7+ compiler instances per `createCubeHandlers` call, each with its own metadata cache and query-result cache — so a user composing `load` and `meta` handlers got divergent cache state.

## Fix

Mirror the existing Hono adapter pattern:

- Add optional `semanticLayer?: SemanticLayerCompiler` to `NextAdapterOptions`.
- `createSemanticLayer` returns an injected compiler when present (skipping re-registration), otherwise builds + registers as before.
- `createCubeHandlers` builds the compiler **once** and injects it (`{ ...options, semanticLayer }`) into every handler it returns (load, meta, sql, dryRun, batch, explain, mcpRpc, agentChat).
- Standalone single-handler factories keep their signature and still build their own compiler.

## Tests (TDD)

Added to `tests/adapters/nextjs.test.ts` (spy on `SemanticLayerCompiler.prototype.registerCube`):
- **single shared compiler** — all `createCubeHandlers` handlers backed by one instance; cubes registered exactly once (was 7 instances)
- **standalone independence** — two separate factory calls build two distinct compilers
- **functional** — `load`/`meta` from `createCubeHandlers` respond through the shared compiler

## Acceptance criteria

- [x] `createCubeHandlers` constructs exactly one `SemanticLayerCompiler`, shared across every handler
- [x] Cube registration runs once, not once per handler
- [x] Test asserts a single instance backs all handlers
- [x] Standalone single-handler usage still works
- [x] `npm run typecheck` and `npm run lint` green

Full adapter suite: **334/334** passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)