### PR TITLE
fix(client): operators for measure aggregation types + dev icon names

### DIFF
--- a/dev/client/src/pages/NotebooksListPage.tsx
+++ b/dev/client/src/pages/NotebooksListPage.tsx
@@ -3,7 +3,7 @@ import { useNotebooks, useDeleteNotebook } from '../hooks/useNotebooks'
 import { useNotebookCreate } from './useNotebookCreate'
 import { CreateNotebookModal, NotebookListBody } from './notebookListParts'
 
-const PlusIcon = getIcon('plus')
+const PlusIcon = getIcon('add')
 
 const NOTEBOOK_LIMIT = 20
 

--- a/dev/client/src/pages/notebookListParts.tsx
+++ b/dev/client/src/pages/notebookListParts.tsx
@@ -7,8 +7,8 @@ import { Link } from 'react-router-dom'
 import { getIcon } from '@drizzle-cube/client'
 import type { Notebook } from '../types'
 
-const TrashIcon = getIcon('trash')
-const PlusIcon = getIcon('plus')
+const TrashIcon = getIcon('delete')
+const PlusIcon = getIcon('add')
 const SparklesIcon = getIcon('sparkles')
 
 export function NotebooksLoadingGrid() {

--- a/src/client/components/shared/queryFieldUtils.ts
+++ b/src/client/components/shared/queryFieldUtils.ts
@@ -9,6 +9,7 @@ import type { CubeQuery, SimpleFilter } from '../../types.js'
 import type { MetaResponse } from './types.js'
 import { FILTER_OPERATORS } from './types.js'
 import { getFieldType } from '../../shared/utils.js'
+import { normalizeFilterFieldType } from '../../shared/filters/index.js'
 
 /** Collect the set of field names currently selected by a query. */
 export function getSelectedFieldNames(query: CubeQuery): Set<string> {
@@ -25,7 +26,7 @@ export function getSelectedFieldNames(query: CubeQuery): Set<string> {
  */
 export function validateFilterOperator(filter: SimpleFilter, schema: MetaResponse): string[] {
   const errors: string[] = []
-  const fieldType = getFieldType(filter.member, schema)
+  const fieldType = normalizeFilterFieldType(getFieldType(filter.member, schema))
   const operatorMeta = FILTER_OPERATORS[filter.operator]
 
   if (!operatorMeta) {

--- a/src/client/shared/filters/index.ts
+++ b/src/client/shared/filters/index.ts
@@ -11,7 +11,7 @@ export type { Filter, SimpleFilter, GroupFilter, FilterOperator } from '../../ty
 
 // Operator definitions
 export type { FilterOperatorMeta } from './operators.js'
-export { FILTER_OPERATORS, getAvailableOperators } from './operators.js'
+export { FILTER_OPERATORS, getAvailableOperators, normalizeFilterFieldType } from './operators.js'
 
 // Operations
 export {

--- a/src/client/shared/filters/operators.ts
+++ b/src/client/shared/filters/operators.ts
@@ -277,13 +277,31 @@ export const FILTER_OPERATORS: Record<FilterOperator, FilterOperatorMeta> = {
 }
 
 /**
+ * Field types that drive a non-numeric operator set. Every other field type —
+ * including all measure aggregation types (count, countDistinct, sum, avg,
+ * median, stddev, calculated, movingAvg, rank, …) — is treated as numeric for
+ * the purpose of operator availability and validation.
+ */
+const NON_NUMERIC_FILTER_FIELD_TYPES = new Set(['string', 'time', 'boolean'])
+
+/**
+ * Normalize a raw field/measure type to the category used by FILTER_OPERATORS.
+ * Measure aggregation types collapse to 'number' so the numeric operators apply
+ * (without this, e.g. a `countDistinct` measure would expose no operators).
+ */
+export function normalizeFilterFieldType(fieldType: string): string {
+  return NON_NUMERIC_FILTER_FIELD_TYPES.has(fieldType) ? fieldType : 'number'
+}
+
+/**
  * Get available operators for a field type
  */
 export function getAvailableOperators(fieldType: string): Array<{ operator: string; label: string }> {
+  const normalized = normalizeFilterFieldType(fieldType)
   const operators: Array<{ operator: string; label: string }> = []
 
   for (const [operator, meta] of Object.entries(FILTER_OPERATORS)) {
-    if (meta.fieldTypes.includes(fieldType)) {
+    if (meta.fieldTypes.includes(normalized)) {
       operators.push({
         operator,
         label: meta.label

--- a/tests/client/filterOperations.test.ts
+++ b/tests/client/filterOperations.test.ts
@@ -11,6 +11,7 @@ import {
   // operators
   FILTER_OPERATORS,
   getAvailableOperators,
+  normalizeFilterFieldType,
   // type guards
   isSimpleFilter,
   isGroupFilter,
@@ -75,8 +76,26 @@ describe('shared/filters', () => {
       expect(ops).not.toContain('contains')
     })
 
-    it('returns nothing for an unknown field type', () => {
-      expect(getAvailableOperators('nonsense')).toEqual([])
+    it('treats measure aggregation types as numeric (regression: countDistinct had no operators)', () => {
+      for (const aggType of ['count', 'countDistinct', 'countDistinctApprox', 'sum', 'avg', 'median', 'stddev', 'calculated', 'movingAvg', 'runningTotal', 'rank']) {
+        const ops = names(aggType)
+        expect(ops, aggType).toEqual(expect.arrayContaining(['equals', 'gt', 'between', 'in', 'set']))
+        expect(ops, aggType).not.toContain('contains')
+      }
+    })
+  })
+
+  describe('normalizeFilterFieldType', () => {
+    it('keeps string, time, and boolean field types', () => {
+      expect(normalizeFilterFieldType('string')).toBe('string')
+      expect(normalizeFilterFieldType('time')).toBe('time')
+      expect(normalizeFilterFieldType('boolean')).toBe('boolean')
+    })
+
+    it('collapses numeric and measure aggregation types to number', () => {
+      for (const t of ['number', 'count', 'countDistinct', 'sum', 'avg', 'median', 'stddev', 'calculated', 'lag', 'rows']) {
+        expect(normalizeFilterFieldType(t), t).toBe('number')
+      }
     })
   })
 


### PR DESCRIPTION
Follow-up to #931. Two fixes surfaced while testing the unified filter module.

## 1. Empty operator dropdown for measures (pre-existing bug)

Opening a filter on a measure whose aggregation type wasn't one of `number`/`count`/`sum`/`avg`/`min`/`max` (e.g. **`countDistinct`** — "Total Employees" in the dev cubes — plus `median`, `stddev`, `calculated`, `movingAvg`, `runningTotal`, `rank`, …) showed **no operators**, because no `FILTER_OPERATORS` entry listed those field types. The default `equals` then couldn't be resolved, so the trigger rendered the raw operator name and logged `Missing translation key: "equals"`.

This predates the refactor — `FILTER_OPERATORS` was moved verbatim in #931; the bug was just easier to hit.

**Fix:** add `normalizeFilterFieldType()` to the filter module — any field type that isn't `string`/`time`/`boolean` collapses to `'number'`, so every numeric measure aggregation type (current and future) gets the numeric operator set. Applied in both gates that read `operator.fieldTypes`:
- `getAvailableOperators` (the dropdown) — `shared/filters/operators.ts`
- `validateFilterOperator` — `components/shared/queryFieldUtils.ts`

A `countDistinct` measure now offers `equals`, comparisons, `in`/`notIn`, `set`/`notSet`, and the operator label resolves. Added regression tests.

## 2. Dev app icon names

The dev app called `getIcon('plus')` and `getIcon('trash')` — neither is a registered `IconName` (the registry registers the heroicons under `add` and `delete`), producing runtime `Icon "x" not found in registry, using fallback` warnings. Corrected to `add`/`delete`. Audited every `getIcon('…')` literal across `src` + `dev` — all now resolve. (The dev client isn't part of the gated `typecheck`, so these slipped through.)

## Gate
`npm run typecheck` ✅ · `npm run lint` ✅ · `npm run test:client` ✅ 5895 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)