### PR TITLE
[Docs] Strengthen agent context: DB-free tests + generator conventions (#939)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ src/server/      # Core semantic layer — compiler, executors, query planning  
 src/client/      # React analytics dashboard components                       → src/client/CLAUDE.md
 src/adapters/    # Framework adapters (Express, Fastify, Hono, Next.js)       → src/adapters/CLAUDE.md
 src/i18n/        # Internationalization runtime and locale files               → src/i18n/CLAUDE.md
-src/cli/         # CLI tool — `npx drizzle-cube charts init|list`
+src/cli/         # CLI tool — `npx drizzle-cube charts init|list`            → src/cli/CLAUDE.md
 src/shared/      # Shared utilities (date-range parsing)
 tests/           # Multi-database testing infrastructure                      → tests/CLAUDE.md
 dev/             # Development environment: example server, Docker Compose, migrations, seed
@@ -61,7 +61,7 @@ Each engine has a dedicated executor in `src/server/executors/`. Auto-detection 
 ## Core Principles
 
 - **Drizzle-first** — all SQL generation uses Drizzle ORM exclusively
-- **TypeScript-only** — strict type checking throughout
+- **TypeScript-only** — strict type checking throughout. A passing `npm run typecheck` is **necessary, not sufficient**: never use `as any`, and never use a type assertion to bypass a local validator or type guard. If a validator exists for a config/artifact shape, route values through it rather than casting around it to silence the compiler.
 - **Security-first** — multi-tenant isolation is mandatory
 - **Modular** — separate entry points: `drizzle-cube/server`, `drizzle-cube/client`, `drizzle-cube/adapters/*`
 - **Cube.js compatible** — API compatibility for easy migration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,21 @@ Drizzle Cube has integration tests that run against real databases with differen
 
 If you have added additional logic to the core library, make sure that all tests complete without any failures.
 
+> [!IMPORTANT]
+> **Not every test needs a database.** `vitest.config.ts` defines a DB-free `cli` project
+> (alongside `server` and `client`). Logic that never opens a connection or builds SQL — CLI
+> commands, manifest/artifact parsers, code generators, naming and type mapping — goes in
+> `tests/cli/`, runs with in-memory fixtures, needs **no Docker and no `globalSetup`**, and
+> finishes in milliseconds:
+>
+> ```bash
+> npm run test:cli   # DB-free CLI / parser / codegen tests — no containers required
+> ```
+>
+> Reserve the `server` / engine projects for code that actually **issues SQL**. Decide by the
+> subject under test, not by where its source file lives — see `tests/CLAUDE.md` and the live
+> project definitions in `vitest.config.ts`.
+
 > [!NOTE]
 > If you have added data types, query features, or new functionality, you need to create additional test cases using the new API to ensure it works properly.
 

--- a/package.json
+++ b/package.json
@@ -170,6 +170,8 @@
     "build:cli": "vite build --config vite.config.cli.ts",
     "test": "vitest run",
     "test:watch": "vitest --watch",
+    "test:cli": "vitest run --project cli",
+    "test:cli:watch": "vitest --watch --project cli",
     "test:server": "vitest run --config vitest.config.server.ts",
     "test:server:watch": "vitest --watch --config vitest.config.server.ts",
     "test:coverage": "vitest run --coverage",

--- a/src/cli/CLAUDE.md
+++ b/src/cli/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLI — `drizzle-cube`
+
+The `drizzle-cube` binary (`bin` → `dist/cli/index.cjs`). Entry point `index.ts` routes
+positional args to commands under `commands/`. Keep the CLI a thin, deterministic, **DB-free**
+layer — it generates and scaffolds files; it never connects to a database.
+
+## Structure
+
+```
+src/cli/
+├── index.ts            # arg routing (node:util parseArgs), top-level error handling
+└── commands/
+    └── charts.ts       # `charts init|list` — scaffold / list custom chart plugins
+```
+
+## Conventions for all CLI code
+
+- **No database, ever.** The CLI reads/writes local files only. It must run with no Docker,
+  no connection string, and no network in its core path.
+- **Deterministic output.** Given identical inputs, emit byte-identical files (sort models,
+  columns, joins, and imports). Re-running on unchanged inputs is a zero diff — this is what
+  makes a `--check` / drift mode meaningful.
+- **The I/O boundary is one module.** Keep filesystem reads/writes and interactive prompts at
+  the command edge; keep parsing, normalization, and emission as pure, unit-testable functions.
+
+## Testing
+
+CLI logic is DB-free, so its tests live in the **`cli` vitest project** (`tests/cli/`), not the
+DB-backed `server` project. No Docker, no `globalSetup`, in-memory fixtures, milliseconds.
+
+```bash
+npm run test:cli
+```
+
+See `tests/CLAUDE.md` ("Choosing where a test goes") and the live project definitions in
+`vitest.config.ts`. Decide by the subject under test, not by where the source lives: if it never
+issues SQL, it belongs in `tests/cli/`.
+
+## Type safety
+
+Generators emit code that must typecheck against the real public types. A passing `npm run
+typecheck` is **necessary, not sufficient**:
+
+- **No `as any`**, and no type assertion that bypasses a local validator. If you wrote a
+  validator/guard for a config or artifact shape, route values through it — do not cast around
+  it to silence the compiler. Casting to satisfy `tsc` while skipping the runtime check is a bug,
+  not a fix (this is the failure that motivated #939).
+- Generated cube/schema files must compile against the **public** `drizzle-cube/server` types
+  (the non-generic `Cube` / `QueryContext` surface), exactly as a consumer would import them.
+
+## Generator conventions — `dbt generate` (and any artifact → cube generator)
+
+These are the rules a dbt-artifact → Drizzle-schema/cube generator (see #936) must follow. They
+are written down here so the next contribution lands them by default rather than rediscovering
+them in review.
+
+### Unsupported types → warn and skip
+
+When a catalog/source column maps to a type the generator does not understand, the policy is
+**warn-and-skip**: emit a clear warning naming the model + column + offending type, and omit that
+column. **Never `throw`** (one bad column must not abort the whole run) and **never silently
+default** to a placeholder type (a wrong `text`/`unknown` column is worse than a visible gap).
+The same warn-and-skip cascade applies when a whole model is skipped — any join pointing at a
+skipped model is dropped with its own warning so every emitted reference still resolves.
+
+### Composite / multi-column primary keys → emit, never drop
+
+A model whose primary key spans multiple columns must **not** lose its key. Expected output:
+
+- one **`primaryKey: true` dimension per key column**, and
+- the baseline **`countDistinct` measure** (the standard count for a keyed cube).
+
+A single-column PK is the trivial case of the same rule. The wrong behaviors to guard against are
+silently dropping the composite key (emitting a cube with no PK) or arbitrarily picking one column
+of the key.
+
+### Drift / `--check` → detect removals, not just changes
+
+`--check` (CI/drift mode) must fail when the emitted output no longer matches what the current
+inputs would produce — and that **includes removed sources**, not only changed ones. If a model
+is deleted upstream, its orphaned generated cube file is real drift: `--check` must report it and
+exit non-zero. A `--check` that only diffs files it would currently write (and ignores files it
+would no longer write) passes on real drift — that is the bug to avoid. Compare the **full set**
+of expected outputs against the full set of existing generated outputs.
+
+### Security is explicit, never inferred
+
+The tenant/security column is provided (flag, prompt, or `meta` override) — the generator never
+guesses it. A model missing the configured security column is skipped with a warning (per the
+warn-and-skip rule above), never emitted without row-level isolation.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -29,6 +29,8 @@ tests/
 │   ├── msw-server.ts            MSW server instance
 │   └── test-utils.tsx           renderWithProviders, createHookWrapper, createQueryClientWrapper
 │
+├── cli/                         DB-free CLI / parser / codegen tests (no Docker, no SQL)
+│
 ├── server/                      Server-side unit/integration tests
 │   ├── ai/                      AI discovery, suggestion, validation
 │   ├── executors/               Database executor tests
@@ -64,9 +66,26 @@ tests/
 
 | Config | Scope | Key settings |
 |--------|-------|-------------|
-| `vitest.config.ts` | Workspace root | Threads pool for DuckDB/Databend compatibility |
+| `vitest.config.ts` | Workspace root | Defines the `server`, `cli`, and `client` projects; threads pool for DuckDB/Databend compatibility |
 | `vitest.config.server.ts` | Server tests | `globalSetup.ts`, uses `TEST_DB_TYPE` env var |
 | `vitest.config.client.ts` | Client tests | jsdom environment, React plugin, MSW setup, 75% coverage threshold |
+
+### Choosing where a test goes: DB-free `cli` vs DB-backed `server`
+
+`vitest.config.ts` defines two Node projects (the live example — read it before adding a test):
+
+- **`cli`** — DB-free. **No Docker, no `globalSetup`, no SQL.** Pure logic over in-memory
+  fixtures: CLI commands, artifact/manifest parsers, code generators, naming/type mapping.
+  Tests live in `tests/cli/`, run in **milliseconds**, and need nothing booted. Run them on
+  their own with `npm run test:cli`.
+- **`server`** — DB-backed. Boots a real engine via `globalSetup.ts` and exercises code that
+  **issues SQL** (compiler, executors, query planning). Slower; needs `npm run test:setup` first.
+
+> Decide by the **subject under test, not where its source lives.** If the code under test never
+> opens a connection or builds SQL, it belongs in `tests/cli/` — do **not** park it in `tests/`
+> root or `tests/server/`, where `globalSetup` forces a Postgres you may not be able to start.
+> Both `server` configs explicitly `exclude: ['tests/cli/**']` so a DB-free test never drags in
+> a container; keep new DB-free logic under `tests/cli/` so it stays out of that path.
 
 ## Test Helpers
 
@@ -96,7 +115,8 @@ tests/
 
 | Command | What it runs |
 |---------|-------------|
-| `npm test` | Default server tests (postgres) |
+| `npm test` | All projects (server + cli + client) via `vitest.config.ts` |
+| `npm run test:cli` | DB-free CLI / parser / codegen tests only (no Docker) |
 | `npm run test:server` | Server tests via `vitest.config.server.ts` |
 | `npm run test:mysql` | Server tests against MySQL |
 | `npm run test:sqlite` | Server tests against SQLite |

--- a/tests/cli/charts-list.test.ts
+++ b/tests/cli/charts-list.test.ts
@@ -1,0 +1,33 @@
+/**
+ * DB-free CLI test.
+ *
+ * Lives in the `cli` vitest project (see vitest.config.ts): no Docker, no
+ * globalSetup, no database. Pure logic over in-memory fixtures / captured
+ * output, runs in milliseconds. CLI / parser / codegen tests belong here;
+ * only code that actually issues SQL belongs in the `server` project.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { chartsList } from '../../src/cli/commands/charts'
+
+describe('charts list (DB-free CLI)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('prints the built-in chart catalogue without touching a database', () => {
+    const logged: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logged.push(args.map(String).join(' '))
+    })
+
+    chartsList()
+
+    const output = logged.join('\n')
+    expect(output).toContain('Available built-in chart types')
+    // A representative spread of the catalogue, type + description.
+    expect(output).toContain('bar')
+    expect(output).toContain('Bar chart')
+    expect(output).toContain('funnel')
+    expect(output).toContain('table')
+  })
+})

--- a/vitest.config.server.ts
+++ b/vitest.config.server.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       '**/dist/**',
       '**/cypress/**',
       '**/.{idea,git,cache,output,temp}/**',
+      'tests/cli/**',
       'tests/client/**',
       'tests/e2e/**'
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,9 +41,26 @@ export default defineConfig({
           exclude: [
             '**/node_modules/**',
             '**/dist/**',
+            'tests/cli/**',
             'tests/client/**',
             'tests/e2e/**'
           ],
+        }
+      },
+      {
+        // CLI / generator tests — DB-free. No Docker, no globalSetup, no SQL.
+        // Pure logic over in-memory fixtures; runs in milliseconds. This is the
+        // home for CLI, parser, and codegen tests that never issue a query.
+        extends: true,
+        test: {
+          name: 'cli',
+          globals: true,
+          environment: 'node',
+          include: ['tests/cli/**/*.{test,spec}.ts'],
+          exclude: ['**/node_modules/**', '**/dist/**'],
+          env: {
+            NODE_ENV: 'test'
+          },
         }
       },
       // Only include client tests when not running DB-specific tests


### PR DESCRIPTION
Closes #939.

Derived from the side-by-side review of #936 (built twice as #937/#938). Both met the v1 spec; the weaker PR lost on quality in ways that trace back to gaps in the repo's own agent context, not to the agent's capability. This writes those conventions down so the next contribution lands closer — it is **docs + test-config only**, no generator code (that's still #936/#937/#938).

## Tests — document and wire the DB-free path
The repo previously described only the multi-engine path booted by `globalSetup`, which steers an agent to couple CLI / parser / codegen tests to a Postgres it may not be able to start.

- `vitest.config.ts` gains a **`cli` project**: node env, **no `globalSetup`, no Docker**, globs `tests/cli/**`. The `server` project (here and in `vitest.config.server.ts`) now excludes `tests/cli/**`, so DB-free logic never drags in a container.
- Added a **real seed test** (`tests/cli/charts-list.test.ts`) so the project is a runnable live example, not an empty stub — it runs in ~150ms.
- Added `test:cli` / `test:cli:watch` npm scripts.
- Documented the DB-free vs DB-backed decision in `tests/CLAUDE.md` and `CONTRIBUTING.md`, pointing at `vitest.config.ts` as the live example. Rule: decide by the **subject under test, not where its source lives**.

## Generator conventions — new `src/cli/CLAUDE.md` (+ root index pointer)
Forward-looking rules for the dbt-artifact → cube generator so they land by default rather than being rediscovered in review:
- **Unsupported types** → warn-and-skip; never `throw`, never silently default.
- **Composite / multi-column primary keys** → emit a `primaryKey: true` dimension per key column **plus** the baseline `countDistinct` measure; never silently dropped.
- **Drift / `--check`** → detect *removed* sources (orphaned cube files), comparing the full expected-vs-existing output set, not just changed files.

## Type safety
Sharpened the principle in `CLAUDE.md`: a passing `typecheck` is **necessary, not sufficient** — forbid `as any` and assertions that bypass a local validator.

## Verification
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:cli` ✅ (DB-free, ~150ms, no containers); `cli` project is picked up by the default `npm test` config.

Refs #936, #937, #938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)