### PR TITLE
perf: CPU/memory profiling harness + SQLite result-mapping optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ coverage/
 playwright-report/
 test-results/
 perf-results/
+screenshots/
+.bg-shell/
 dependency-graph.svg
 .fallow/
 

--- a/package.json
+++ b/package.json
@@ -212,6 +212,8 @@
     "quality:graph": "npx madge --image dependency-graph.svg --extensions ts,tsx src",
     "perf": "tsx perf/run.ts",
     "perf:seed": "tsx perf/run.ts --seed-only",
+    "perf:profile": "node --expose-gc --import tsx perf/profile.ts",
+    "perf:route": "node --expose-gc --import tsx perf/route-profile.ts",
     "check:exports": "attw --pack . && publint --level error",
     "prepublishOnly": "npm run lint && npm run typecheck && npm run build && npm run check:exports",
     "dev:db:up": "cd dev && docker-compose up -d",

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,83 @@
+# Performance harness
+
+In-process load + profiling for the server query engine. Both tools drive
+`QueryExecutor` directly against a deterministic ~1M-row Postgres dataset (seeded
+once, version-stamped), so results are repeatable and isolated from HTTP/framework
+noise. Requires the test Postgres running (`npm run test:setup`).
+
+## Timing suite — *which queries are slow*
+
+```bash
+npm run perf                              # all benchmarks, median/p95 per query
+npm run perf -- --filter=joins           # subset by id/category substring
+npm run perf -- --iterations=10 --warmup=3
+npm run perf -- --force-reseed           # rebuild the dataset
+```
+
+Reports land in `perf-results/` (`index.html`, `summary.md`, `results.json`,
+`benchmark.json`). Catalog lives in `benchmarks.ts`.
+
+## Profiler — *which functions are hot / where memory goes*
+
+```bash
+npm run perf:profile                                   # default bench, all modes
+npm run perf:profile -- --list                         # list benchmark ids
+npm run perf:profile -- --bench=compile.complex --mode=cpu    # pure SQL-build (dryRun, no DB)
+npm run perf:profile -- --bench=join.three-cubes --mode=all --snapshot
+npm run perf:profile -- --bench=cache.hit --mode=mem   # result-transform retained heap
+```
+
+Flags: `--bench=<id>` `--mode=cpu|alloc|mem|all` `--iterations=<n>` `--warmup=<n>`
+`--snapshot` `--top=<n>`.
+
+**Pick the right benchmark for CPU work.** `execute` benchmarks wait on the DB, so
+their CPU profile is mostly `(idle)` — the profiler warns and reports shares
+against *active* CPU. To see the query engine working, profile a `dryRun`
+benchmark (`compile.*`, pure plan + SQL build, no DB) or a `cache-hit` benchmark
+(pure result transformation).
+
+### Artifacts (`perf-results/profiles/`)
+
+| File | What | Open in |
+|------|------|---------|
+| `<id>.cpuprofile`  | CPU flamegraph — where CPU time goes        | Chrome DevTools → Performance → Load profile · VS Code · speedscope |
+| `<id>.heapprofile` | allocation flamegraph — where bytes are born | Chrome DevTools → Memory → Load profile |
+| `<id>.heapsnapshot`| full heap — retention drill-down (`--snapshot`) | Chrome DevTools → Memory → Load |
+
+The terminal also prints the top-N hottest frames by self time, so first-pass
+hot-path triage needs no DevTools. `--mode=mem` needs `--expose-gc` (the npm
+script supplies it) for accurate retained-heap deltas — a steady positive
+`KB/iter` signals a leak.
+
+## Real-route profiler — *the full HTTP request path*
+
+Drives the actual Cube load route (`POST /cubejs-api/v1/load`) in-process via the
+Hono adapter over **SQLite** (`better-sqlite3` — synchronous + in-process, so the
+CPU profile has 0% idle: every frame is real request work — routing, security,
+execute, SQL build, DB, result mapping, JSON serialization). No Docker.
+
+```bash
+npm run perf:route                                      # default route, all modes
+npm run perf:route -- --list
+npm run perf:route -- --route=load.ungrouped --mode=cpu    # 5000-row payload, where response time lives
+npm run perf:route -- --mode=time --concurrency=20         # throughput under load
+npm run perf:route -- --mode=mem --iterations=8000         # leak check w/ growth curve
+npm run perf:route -- --vary --mode=mem --iterations=10000 # cycle 96 distinct shapes — stresses per-shape caches
+```
+
+Flags: `--route=<id>` `--mode=cpu|mem|time|all` `--iterations` `--warmup`
+`--concurrency` `--vary` `--top`.
+
+**Memory mode** samples the post-GC heap at checkpoints across the run and reports
+a growth curve plus a second-half least-squares slope (B/req), so a real leak
+(heap climbs linearly to the end) is distinguishable from one-time warmup (rises
+then plateaus). `--vary` round-robins distinct query shapes to expose caches that
+grow unboundedly with query variety. `--snapshot` writes a `.heapsnapshot`.
+
+## Layout
+
+`run.ts` timing entry · `profile.ts` in-process profiling entry · `route-profile.ts`
+real-route (HTTP) profiling entry · `profiler.ts` inspector wrappers (CPU /
+allocation / memory-growth / timing) · `runner.ts` shared per-iteration execution (`makeRunOnce`) ·
+`benchmarks.ts` catalog · `database.ts` seed/connect · `perf-cubes.ts` cubes ·
+`perf-data.ts` deterministic generator · `report/` timing reporters.

--- a/perf/profile.ts
+++ b/perf/profile.ts
@@ -1,0 +1,189 @@
+/**
+ * Profiling entrypoint: drive a single benchmark in a tight in-process loop and
+ * capture CPU / allocation / memory profiles of the query engine. Run from repo root:
+ *
+ *   npm run perf:profile                                  default bench, all modes
+ *   npm run perf:profile -- --bench=compile.complex --mode=cpu   pure SQL-build (dryRun, no DB)
+ *   npm run perf:profile -- --bench=join.three-cubes --mode=all
+ *   npm run perf:profile -- --bench=cache.hit --mode=mem --snapshot
+ *   npm run perf:profile -- --list                        list benchmark ids
+ *
+ * Flags: --bench=<id> --mode=cpu|alloc|mem|all --iterations=<n> --warmup=<n> --snapshot --top=<n>
+ *
+ * In-process load drives QueryExecutor directly, so the DB round-trip shows as
+ * idle time and the CPU flamegraph is dominated by the actual query-engine JS.
+ * Profile a `dryRun` benchmark (compile.*) to isolate plan/SQL-build with no DB;
+ * a `cache-hit` benchmark to isolate result transformation.
+ *
+ * Artifacts land in perf-results/profiles/ — open .cpuprofile/.heapprofile in
+ * Chrome DevTools (Performance / Memory → Load profile), VS Code, or speedscope.
+ */
+
+import { createPostgresExecutor, MemoryCacheProvider } from '../src/server'
+import { QueryExecutor } from '../src/server/executor'
+import { testSchema } from '../tests/helpers/databases/postgres/schema'
+import { BENCHMARKS } from './benchmarks'
+import { connectPerf, ensurePerfDatabase, ensureSeeded } from './database'
+import { getPerfCubes } from './perf-cubes'
+import { makeRunOnce, resolveSecurityContext, type RunnerContext } from './runner'
+import {
+  measureMemory,
+  measureTiming,
+  profileCpu,
+  profileHeapAllocations,
+  summarizeCpuProfile,
+  PROFILES_DIR,
+  type RunOnce
+} from './profiler'
+
+type ProfileMode = 'cpu' | 'alloc' | 'mem' | 'time' | 'all'
+
+interface CliOptions {
+  benchId: string
+  mode: ProfileMode
+  iterations: number
+  warmup: number
+  snapshot: boolean
+  top: number
+  list: boolean
+}
+
+const DEFAULT_BENCH = 'join.three-cubes'
+const VALID_MODES: ProfileMode[] = ['cpu', 'alloc', 'mem', 'time', 'all']
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    benchId: DEFAULT_BENCH,
+    mode: 'all',
+    iterations: Number(process.env.PROFILE_ITERATIONS) || 500,
+    warmup: Number(process.env.PROFILE_WARMUP) || 20,
+    snapshot: argv.includes('--snapshot'),
+    top: 20,
+    list: argv.includes('--list')
+  }
+  for (const arg of argv) {
+    if (arg.startsWith('--bench=')) options.benchId = arg.slice('--bench='.length)
+    if (arg.startsWith('--mode=')) options.mode = arg.slice('--mode='.length) as ProfileMode
+    if (arg.startsWith('--iterations=')) options.iterations = Number(arg.slice('--iterations='.length))
+    if (arg.startsWith('--warmup=')) options.warmup = Number(arg.slice('--warmup='.length))
+    if (arg.startsWith('--top=')) options.top = Number(arg.slice('--top='.length))
+  }
+  if (!VALID_MODES.includes(options.mode)) {
+    throw new Error(`Invalid --mode "${options.mode}" (expected ${VALID_MODES.join('|')})`)
+  }
+  if (!Number.isFinite(options.iterations) || options.iterations < 1) {
+    throw new Error(`Invalid iterations: ${options.iterations}`)
+  }
+  if (!Number.isFinite(options.warmup) || options.warmup < 0) {
+    throw new Error(`Invalid warmup: ${options.warmup}`)
+  }
+  return options
+}
+
+function listBenchmarks(): void {
+  let category = ''
+  for (const def of BENCHMARKS) {
+    if (def.category !== category) {
+      category = def.category
+      console.log(`\n  ${category}`)
+    }
+    console.log(`    ${def.id.padEnd(32)} [${def.mode}]  ${def.name}`)
+  }
+  console.log('')
+}
+
+function fmtBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024)
+  if (Math.abs(mb) >= 1) return `${mb.toFixed(2)} MB`
+  return `${(bytes / 1024).toFixed(1)} KB`
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2))
+
+  if (options.list) {
+    listBenchmarks()
+    return
+  }
+
+  const def = BENCHMARKS.find(b => b.id === options.benchId)
+  if (!def) {
+    throw new Error(`Unknown benchmark "${options.benchId}". Run with --list to see available ids.`)
+  }
+
+  await ensurePerfDatabase()
+  const { db, close } = await connectPerf()
+
+  try {
+    await ensureSeeded(db)
+
+    const dbExecutor = createPostgresExecutor(db, testSchema)
+    const ctx: RunnerContext = {
+      executor: new QueryExecutor(dbExecutor),
+      cachedExecutor: new QueryExecutor(dbExecutor, { provider: new MemoryCacheProvider() }),
+      cubes: await getPerfCubes()
+    }
+
+    const runOnce: RunOnce = makeRunOnce(def, ctx, resolveSecurityContext(def))
+    const label = def.id
+
+    console.log(`\nProfiling "${def.id}" [${def.mode}] — ${def.name}`)
+    console.log(`  iterations=${options.iterations}  warmup=${options.warmup}  mode=${options.mode}\n`)
+
+    // Warm the JIT, connection, and any per-process caches before measuring.
+    for (let i = 0; i < options.warmup; i++) await runOnce()
+
+    const wantTime = options.mode === 'time'
+    const wantCpu = options.mode === 'cpu' || options.mode === 'all'
+    const wantAlloc = options.mode === 'alloc' || options.mode === 'all'
+    const wantMem = options.mode === 'mem' || options.mode === 'all'
+
+    if (wantTime) {
+      const t = await measureTiming(runOnce, options.iterations, options.warmup)
+      console.log(`  Timing (${t.iterations} iters): median ${t.medianUs}µs · mean ${t.meanUs}µs · p95 ${t.p95Us}µs · p99 ${t.p99Us}µs · min ${t.minUs}µs · ${t.opsPerSec.toLocaleString()} ops/sec`)
+      console.log(`\nDone.`)
+      return
+    }
+
+    if (wantCpu) {
+      const profile = await profileCpu(label, runOnce, options.iterations)
+      const { totalMs, idleMs, activeMs, frames } = summarizeCpuProfile(profile, options.top)
+      const idlePct = totalMs > 0 ? (idleMs / totalMs) * 100 : 0
+      console.log(`  CPU profile → ${PROFILES_DIR}/${label}.cpuprofile  (${totalMs.toFixed(0)}ms wall · ${activeMs.toFixed(0)}ms active CPU · ${idlePct.toFixed(0)}% idle/IO)`)
+      if (idlePct > 50) {
+        console.log(`  ⚠ mostly idle — this benchmark waits on the DB. Use a dryRun (compile.*) or cache-hit bench to profile pure CPU.`)
+      }
+      console.log(`\n  Top ${frames.length} frames by self time (share of active CPU):`)
+      console.log(`  ${'self'.padStart(9)}  ${'share'.padStart(6)}  frame`)
+      console.log(`  ${'-'.repeat(72)}`)
+      for (const f of frames) {
+        const self = `${f.selfMs.toFixed(1)}ms`.padStart(9)
+        const share = `${(f.share * 100).toFixed(1)}%`.padStart(6)
+        console.log(`  ${self}  ${share}  ${f.label}`)
+      }
+      console.log('')
+    }
+
+    if (wantAlloc) {
+      await profileHeapAllocations(label, runOnce, options.iterations)
+      console.log(`  Allocation profile → ${PROFILES_DIR}/${label}.heapprofile  (open in Chrome DevTools → Memory)`)
+    }
+
+    if (wantMem) {
+      const mem = await measureMemory(label, runOnce, options.iterations, { snapshot: options.snapshot })
+      console.log(`  Memory: retained ${fmtBytes(mem.retainedBytes)} total · ${fmtBytes(mem.retainedPerIterationBytes)}/iter · peak heap ${fmtBytes(mem.peakBytes)}${mem.gcAvailable ? '' : ' (no --expose-gc: approximate)'}`)
+      if (mem.snapshotPath) console.log(`  Heap snapshot → ${mem.snapshotPath}  (open in Chrome DevTools → Memory → Load)`)
+    }
+
+    console.log(`\nDone. Artifacts in ${PROFILES_DIR}/`)
+  } finally {
+    close()
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error('Profiling run failed:', error)
+    process.exit(1)
+  })

--- a/perf/profiler.ts
+++ b/perf/profiler.ts
@@ -1,0 +1,324 @@
+/**
+ * Profiling primitives built on Node's bundled inspector (no extra deps).
+ *
+ * Each helper wraps ONLY the measured loop in an inspector session so the
+ * surrounding seed/connect/warmup work never lands in the profile. Artifacts
+ * are written under `perf-results/profiles/` and open as flamegraphs in Chrome
+ * DevTools (Performance / Memory → Load profile), VS Code, or speedscope.
+ *
+ *   .cpuprofile    CPU flamegraph — where wall-clock CPU time is spent
+ *   .heapprofile   allocation flamegraph — where bytes are allocated
+ *   .heapsnapshot  full heap — retention drill-down for leak hunting
+ */
+
+import { Session } from 'node:inspector'
+import { writeHeapSnapshot } from 'node:v8'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
+export const PROFILES_DIR = join('perf-results', 'profiles')
+
+/** One run-the-loop thunk: executes a single benchmark iteration. */
+export type RunOnce = () => Promise<unknown>
+
+/** A node from a V8 .cpuprofile, plus the per-node sample counts/timings. */
+interface CpuProfileNode {
+  id: number
+  callFrame: { functionName: string; url: string; lineNumber: number }
+  hitCount?: number
+  children?: number[]
+}
+
+export interface CpuProfile {
+  nodes: CpuProfileNode[]
+  startTime: number
+  endTime: number
+  samples?: number[]
+  timeDeltas?: number[]
+}
+
+export interface HotFrame {
+  /** `functionName (url:line)` — `(anonymous)` and native frames kept as-is */
+  label: string
+  /** Self CPU time attributed to this frame, in milliseconds */
+  selfMs: number
+  /** Share of total profiled CPU time, 0..1 */
+  share: number
+}
+
+function ensureProfilesDir(): void {
+  mkdirSync(PROFILES_DIR, { recursive: true })
+}
+
+async function withSession<T>(fn: (post: <R = unknown>(method: string, params?: object) => Promise<R>) => Promise<T>): Promise<T> {
+  const session = new Session()
+  session.connect()
+  const rawPost = promisify(session.post.bind(session)) as (method: string, params?: object) => Promise<unknown>
+  const post = <R = unknown>(method: string, params?: object) => rawPost(method, params) as Promise<R>
+  try {
+    return await fn(post)
+  } finally {
+    session.disconnect()
+  }
+}
+
+async function runLoop(runOnce: RunOnce, iterations: number): Promise<void> {
+  for (let i = 0; i < iterations; i++) {
+    await runOnce()
+  }
+}
+
+/**
+ * Capture a CPU profile of `iterations` runs and write `<label>.cpuprofile`.
+ * Returns the parsed profile so the caller can print a terminal hot-frame
+ * summary without opening DevTools.
+ */
+export async function profileCpu(label: string, runOnce: RunOnce, iterations: number): Promise<CpuProfile> {
+  ensureProfilesDir()
+  const profile = await withSession(async post => {
+    await post('Profiler.enable')
+    // 100µs sampling — finer than the 1ms default so short query-engine frames register.
+    await post('Profiler.setSamplingInterval', { interval: 100 })
+    await post('Profiler.start')
+    await runLoop(runOnce, iterations)
+    const { profile } = await post<{ profile: CpuProfile }>('Profiler.stop')
+    return profile
+  })
+  const path = join(PROFILES_DIR, `${label}.cpuprofile`)
+  writeFileSync(path, JSON.stringify(profile))
+  return profile
+}
+
+/**
+ * Capture a sampling allocation profile of `iterations` runs and write
+ * `<label>.heapprofile` (open under Chrome DevTools → Memory → Load profile).
+ */
+export async function profileHeapAllocations(label: string, runOnce: RunOnce, iterations: number): Promise<void> {
+  ensureProfilesDir()
+  const profile = await withSession(async post => {
+    await post('HeapProfiler.enable')
+    await post('HeapProfiler.startSampling', { samplingInterval: 16384 })
+    await runLoop(runOnce, iterations)
+    const { profile } = await post<{ profile: unknown }>('HeapProfiler.stopSampling')
+    return profile
+  })
+  writeFileSync(join(PROFILES_DIR, `${label}.heapprofile`), JSON.stringify(profile))
+}
+
+export interface TimingResult {
+  iterations: number
+  /** All in microseconds. */
+  medianUs: number
+  meanUs: number
+  p95Us: number
+  p99Us: number
+  minUs: number
+  /** Iterations per second derived from the median. */
+  opsPerSec: number
+}
+
+/**
+ * High-resolution timing of the compile/CPU path — finer than the timing suite's
+ * 2-decimal millisecond reporting, so sub-millisecond improvements are visible.
+ * Uses `process.hrtime.bigint()` (nanosecond clock); reports microseconds.
+ * This is the objective KPI for the optimization loop.
+ */
+export async function measureTiming(runOnce: RunOnce, iterations: number, warmup: number): Promise<TimingResult> {
+  for (let i = 0; i < warmup; i++) await runOnce()
+
+  const samplesNs = new Array<number>(iterations)
+  for (let i = 0; i < iterations; i++) {
+    const start = process.hrtime.bigint()
+    await runOnce()
+    samplesNs[i] = Number(process.hrtime.bigint() - start)
+  }
+
+  samplesNs.sort((a, b) => a - b)
+  const n = samplesNs.length
+  const pct = (p: number) => samplesNs[Math.min(n - 1, Math.ceil((p / 100) * n) - 1)]
+  const median = n % 2 === 0 ? (samplesNs[n / 2 - 1] + samplesNs[n / 2]) / 2 : samplesNs[(n - 1) / 2]
+  const meanNs = samplesNs.reduce((s, v) => s + v, 0) / n
+
+  const toUs = (ns: number) => Math.round((ns / 1000) * 100) / 100
+  return {
+    iterations,
+    medianUs: toUs(median),
+    meanUs: toUs(meanNs),
+    p95Us: toUs(pct(95)),
+    p99Us: toUs(pct(99)),
+    minUs: toUs(samplesNs[0]),
+    opsPerSec: Math.round(1_000_000_000 / median)
+  }
+}
+
+export interface MemoryCheckpoint {
+  /** Iterations completed at this checkpoint. */
+  atIteration: number
+  /** Post-GC heapUsed minus the pre-loop baseline, in bytes. */
+  retainedBytes: number
+}
+
+export interface MemoryResult {
+  /** Net retained heap growth across the whole loop, in bytes (post-GC). */
+  retainedBytes: number
+  /** retainedBytes / iterations — a steady positive value signals a leak. */
+  retainedPerIterationBytes: number
+  /** Peak heapUsed observed mid-loop, in bytes. */
+  peakBytes: number
+  iterations: number
+  /** Post-GC retained heap sampled at evenly-spaced checkpoints (growth curve). */
+  checkpoints: MemoryCheckpoint[]
+  /**
+   * Per-request slope (bytes) over the SECOND HALF of the run, where one-time
+   * warmup (cache fills, JIT) has settled. ~0 ⇒ stable; steadily positive ⇒ leak.
+   */
+  steadyStatePerIterationBytes: number
+  /** False when run without --expose-gc; deltas then include uncollected garbage. */
+  gcAvailable: boolean
+  /** Path to the written heap snapshot, when requested. */
+  snapshotPath?: string
+}
+
+/**
+ * Measure retained-heap growth across `iterations` runs, sampling the post-GC
+ * heap at evenly-spaced checkpoints so a true leak (heap climbs linearly to the
+ * end) is distinguishable from one-time warmup (heap rises then plateaus).
+ *
+ * Forces GC at every checkpoint (requires `--expose-gc`) so each sample reflects
+ * RETAINED memory, not uncollected garbage. The steady-state slope is fit over
+ * the second half of the run, after warmup has settled. When `snapshot` is set,
+ * also writes `<label>.heapsnapshot` for retention drill-down in DevTools.
+ */
+export async function measureMemory(
+  label: string,
+  runOnce: RunOnce,
+  iterations: number,
+  options: { snapshot?: boolean; segments?: number } = {}
+): Promise<MemoryResult> {
+  const gc = (globalThis as { gc?: () => void }).gc
+  const gcAvailable = typeof gc === 'function'
+  if (!gcAvailable) {
+    console.warn('  ⚠ global.gc unavailable — run via `npm run perf:route`/`perf:profile` (node --expose-gc) for accurate retained-heap deltas')
+  }
+
+  const segments = Math.max(2, Math.min(options.segments ?? 10, iterations))
+  const segmentSize = Math.floor(iterations / segments)
+
+  gc?.()
+  const before = process.memoryUsage().heapUsed
+  let peak = before
+  const checkpoints: MemoryCheckpoint[] = []
+
+  let done = 0
+  for (let s = 0; s < segments; s++) {
+    const target = s === segments - 1 ? iterations : done + segmentSize
+    for (; done < target; done++) {
+      await runOnce()
+      const used = process.memoryUsage().heapUsed
+      if (used > peak) peak = used
+    }
+    gc?.()
+    checkpoints.push({ atIteration: done, retainedBytes: process.memoryUsage().heapUsed - before })
+  }
+
+  let snapshotPath: string | undefined
+  if (options.snapshot) {
+    ensureProfilesDir()
+    snapshotPath = join(PROFILES_DIR, `${label}.heapsnapshot`)
+    writeHeapSnapshot(snapshotPath)
+  }
+
+  const retainedBytes = checkpoints[checkpoints.length - 1].retainedBytes
+  return {
+    retainedBytes,
+    retainedPerIterationBytes: retainedBytes / iterations,
+    peakBytes: peak,
+    iterations,
+    checkpoints,
+    steadyStatePerIterationBytes: secondHalfSlope(checkpoints),
+    gcAvailable,
+    snapshotPath
+  }
+}
+
+/**
+ * Least-squares slope (bytes per iteration) over the checkpoints in the second
+ * half of the run — the window where one-time warmup has settled, so a positive
+ * slope here is the real leak signal.
+ */
+function secondHalfSlope(checkpoints: MemoryCheckpoint[]): number {
+  const half = checkpoints.slice(Math.floor(checkpoints.length / 2))
+  if (half.length < 2) return 0
+  const n = half.length
+  let sx = 0, sy = 0, sxy = 0, sxx = 0
+  for (const c of half) {
+    sx += c.atIteration
+    sy += c.retainedBytes
+    sxy += c.atIteration * c.retainedBytes
+    sxx += c.atIteration * c.atIteration
+  }
+  const denom = n * sxx - sx * sx
+  return denom === 0 ? 0 : (n * sxy - sx * sy) / denom
+}
+
+export interface CpuSummary {
+  /** Total profiled wall time, ms. */
+  totalMs: number
+  /** Time the sampler caught the process idle (waiting on I/O — e.g. the DB), ms. */
+  idleMs: number
+  /** totalMs - idleMs: time actually running JS/native CPU work, ms. */
+  activeMs: number
+  /** Hottest frames by self time, EXCLUDING the synthetic `(idle)` node. Shares are of activeMs. */
+  frames: HotFrame[]
+}
+
+/**
+ * Aggregate a .cpuprofile down to the top-N frames by self time. Self time per
+ * node is `hitCount × averageSampleInterval`; we sum across nodes that share a
+ * `functionName (url:line)` identity so recursive/re-entrant frames collapse.
+ *
+ * V8's synthetic `(idle)` node (CPU parked waiting on I/O, e.g. the DB
+ * round-trip in `execute` mode) is split out separately so it never crowds the
+ * table — frame shares are taken against active CPU time, not wall time.
+ */
+export function summarizeCpuProfile(profile: CpuProfile, topN = 20): CpuSummary {
+  const totalMs = (profile.endTime - profile.startTime) / 1000
+  const totalHits = profile.nodes.reduce((sum, n) => sum + (n.hitCount ?? 0), 0)
+  const msPerHit = totalHits > 0 ? totalMs / totalHits : 0
+
+  let idleMs = 0
+  const byFrame = new Map<string, number>()
+  for (const node of profile.nodes) {
+    const hits = node.hitCount ?? 0
+    if (hits === 0) continue
+    const { functionName, url, lineNumber } = node.callFrame
+    const name = functionName || '(anonymous)'
+    if (name === '(idle)') {
+      idleMs += hits * msPerHit
+      continue
+    }
+    const location = url ? `${shorten(url)}:${lineNumber + 1}` : '(native)'
+    const label = `${name} (${location})`
+    byFrame.set(label, (byFrame.get(label) ?? 0) + hits * msPerHit)
+  }
+
+  const activeMs = totalMs - idleMs
+  const frames: HotFrame[] = [...byFrame.entries()]
+    .map(([label, selfMs]) => ({ label, selfMs, share: activeMs > 0 ? selfMs / activeMs : 0 }))
+    .sort((a, b) => b.selfMs - a.selfMs)
+    .slice(0, topN)
+
+  return { totalMs, idleMs, activeMs, frames }
+}
+
+/** Trim absolute/file URLs to a repo-relative-ish tail for readable tables. */
+function shorten(url: string): string {
+  const clean = url.replace(/^file:\/\//, '')
+  const marker = clean.lastIndexOf('/src/')
+  if (marker !== -1) return clean.slice(marker + 1)
+  const perfMarker = clean.lastIndexOf('/perf/')
+  if (perfMarker !== -1) return clean.slice(perfMarker + 1)
+  const parts = clean.split('/')
+  return parts.slice(-2).join('/')
+}

--- a/perf/route-profile.ts
+++ b/perf/route-profile.ts
@@ -1,0 +1,301 @@
+/**
+ * Real-route profiling: drive the actual HTTP route handler in-process and
+ * profile the FULL request path — Hono routing → security extraction → core
+ * load handler → SemanticLayerCompiler → QueryExecutor → SQL build → DB →
+ * result mapping → Cube response formatting → JSON serialization.
+ *
+ * Backed by SQLite (better-sqlite3): synchronous + in-process, so there is NO
+ * network idle — every microsecond in the CPU profile is real request work.
+ * Zero Docker, fully repeatable. Run from repo root:
+ *
+ *   npm run perf:route                                    default route, all modes
+ *   npm run perf:route -- --route=load.join --mode=cpu
+ *   npm run perf:route -- --route=load.timeseries --mode=time --iterations=5000
+ *   npm run perf:route -- --mode=time --concurrency=20    throughput under load
+ *   npm run perf:route -- --list
+ *
+ * Flags: --route=<id> --mode=cpu|mem|time|all --iterations=<n> --warmup=<n>
+ *        --concurrency=<n> --top=<n>
+ *
+ * Artifacts land in perf-results/profiles/ — open .cpuprofile in Chrome DevTools.
+ */
+
+// SQLite test helpers read TEST_DB_TYPE at call time — set before any of them run.
+process.env.TEST_DB_TYPE = 'sqlite'
+
+import type { SemanticQuery } from '../src/server/types'
+import { createCubeApp } from '../src/adapters/hono'
+import { getTestSchema } from '../tests/helpers/test-database'
+import { getTestCubes } from '../tests/helpers/test-cubes'
+import { setupSQLiteDatabase } from '../tests/helpers/databases/sqlite/setup'
+import { testSecurityContexts } from '../tests/helpers/enhanced-test-data'
+import {
+  measureMemory,
+  measureTiming,
+  profileCpu,
+  summarizeCpuProfile,
+  PROFILES_DIR,
+  type RunOnce
+} from './profiler'
+
+type RouteMode = 'cpu' | 'mem' | 'time' | 'all'
+
+interface RouteDef {
+  id: string
+  name: string
+  query: SemanticQuery
+}
+
+/**
+ * Representative load queries over the standard SQLite test cubes
+ * (Employees / Departments / Productivity / TimeEntries).
+ */
+const ROUTES: RouteDef[] = [
+  { id: 'load.count', name: 'Single count measure', query: { measures: ['Employees.count'] } },
+  {
+    id: 'load.groupby',
+    name: 'Group by department name',
+    query: { measures: ['Employees.count', 'Employees.avgSalary'], dimensions: ['Departments.name'] }
+  },
+  {
+    id: 'load.join',
+    name: 'Join employees → departments with filter',
+    query: {
+      measures: ['Employees.count', 'Employees.avgSalary'],
+      dimensions: ['Departments.name'],
+      filters: [{ member: 'Employees.salary', operator: 'gt', values: [0] }]
+    }
+  },
+  {
+    id: 'load.timeseries',
+    name: 'Monthly productivity time series',
+    query: {
+      measures: ['Productivity.totalLinesOfCode', 'Productivity.recordCount'],
+      timeDimensions: [{ dimension: 'Productivity.date', granularity: 'month' }]
+    }
+  },
+  {
+    id: 'load.ungrouped',
+    name: 'Ungrouped raw rows (serialization-heavy)',
+    query: {
+      dimensions: ['Productivity.employeeId', 'Productivity.date', 'Productivity.linesOfCode'],
+      measures: ['Productivity.totalLinesOfCode'],
+      ungrouped: true,
+      limit: 5000
+    }
+  }
+]
+
+/**
+ * A pool of DISTINCT query shapes (different measure/dimension/filter/limit
+ * combinations → different generated SQL strings). Cycling these instead of one
+ * fixed query stresses any per-shape cache (compiler metadata/plan caches, the
+ * driver's prepared-statement cache): if such a cache is unbounded, retained
+ * heap climbs with the number of distinct shapes seen rather than plateauing.
+ */
+function variedQueries(): SemanticQuery[] {
+  const measureSets = [
+    ['Employees.count'],
+    ['Employees.count', 'Employees.avgSalary'],
+    ['Productivity.recordCount', 'Productivity.totalLinesOfCode'],
+    ['TimeEntries.count', 'TimeEntries.totalHours']
+  ]
+  const dimensionSets = [
+    undefined,
+    ['Departments.name'],
+    ['TimeEntries.allocationType'],
+    ['Productivity.employeeId']
+  ]
+  const queries: SemanticQuery[] = []
+  for (let m = 0; m < measureSets.length; m++) {
+    for (let d = 0; d < dimensionSets.length; d++) {
+      const dims = dimensionSets[d]
+      // Skip combinations whose cubes don't line up with the measures.
+      const cube = measureSets[m][0].split('.')[0]
+      const dimCube = dims?.[0]?.split('.')[0]
+      if (dims && dimCube !== cube && dimCube !== 'Departments') continue
+      for (let lim = 0; lim < 6; lim++) {
+        queries.push({
+          measures: measureSets[m],
+          dimensions: dims,
+          filters: [{ member: `${cube}.id`, operator: 'gt', values: [lim * 3] }],
+          limit: 50 + lim * 25
+        })
+      }
+    }
+  }
+  return queries
+}
+
+const DEFAULT_ROUTE = 'load.join'
+const VALID_MODES: RouteMode[] = ['cpu', 'mem', 'time', 'all']
+const BASE_PATH = '/cubejs-api/v1'
+
+interface CliOptions {
+  routeId: string
+  mode: RouteMode
+  iterations: number
+  warmup: number
+  concurrency: number
+  top: number
+  list: boolean
+  vary: boolean
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    routeId: DEFAULT_ROUTE,
+    mode: 'all',
+    iterations: 2000,
+    warmup: 200,
+    concurrency: 1,
+    top: 25,
+    list: argv.includes('--list'),
+    vary: argv.includes('--vary')
+  }
+  for (const arg of argv) {
+    if (arg.startsWith('--route=')) options.routeId = arg.slice('--route='.length)
+    if (arg.startsWith('--mode=')) options.mode = arg.slice('--mode='.length) as RouteMode
+    if (arg.startsWith('--iterations=')) options.iterations = Number(arg.slice('--iterations='.length))
+    if (arg.startsWith('--warmup=')) options.warmup = Number(arg.slice('--warmup='.length))
+    if (arg.startsWith('--concurrency=')) options.concurrency = Number(arg.slice('--concurrency='.length))
+    if (arg.startsWith('--top=')) options.top = Number(arg.slice('--top='.length))
+  }
+  if (!VALID_MODES.includes(options.mode)) {
+    throw new Error(`Invalid --mode "${options.mode}" (expected ${VALID_MODES.join('|')})`)
+  }
+  for (const [k, v] of [['iterations', options.iterations], ['warmup', options.warmup], ['concurrency', options.concurrency]] as const) {
+    if (!Number.isFinite(v) || v < (k === 'warmup' ? 0 : 1)) throw new Error(`Invalid ${k}: ${v}`)
+  }
+  return options
+}
+
+function fmtBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024)
+  return Math.abs(mb) >= 1 ? `${mb.toFixed(2)} MB` : `${(bytes / 1024).toFixed(1)} KB`
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2))
+
+  if (options.list) {
+    for (const r of ROUTES) console.log(`  ${r.id.padEnd(18)} ${r.name}`)
+    return
+  }
+
+  const route = ROUTES.find(r => r.id === options.routeId)
+  if (!route) {
+    throw new Error(`Unknown route "${options.routeId}". Run with --list to see ids.`)
+  }
+
+  console.log('Booting SQLite + cube app (in-process)...')
+  const { db, close } = await setupSQLiteDatabase()
+
+  try {
+    const schema = (await getTestSchema()).schema
+    const cubes = await getTestCubes()
+
+    const app = createCubeApp({
+      cubes: [...cubes.values()],
+      drizzle: db,
+      schema,
+      engineType: 'sqlite',
+      extractSecurityContext: () => testSecurityContexts.org1,
+      mcp: { enabled: false }
+    })
+
+    // Bodies to drive the route with. Default: one fixed query. With --vary:
+    // a pool of distinct query shapes, round-robined, to stress per-shape caches.
+    const queries = options.vary ? variedQueries() : [route.query]
+    const bodies = queries.map(q => JSON.stringify({ query: q }))
+    const headers = { 'Content-Type': 'application/json' }
+    let cursor = 0
+
+    // One real round-trip through the route handler. Validates status + payload
+    // so we never profile an error path, and returns the row count.
+    const runOnce: RunOnce = async () => {
+      const body = bodies[cursor++ % bodies.length]
+      const res = await app.request(`${BASE_PATH}/load`, { method: 'POST', headers, body })
+      if (res.status !== 200) {
+        throw new Error(`Route returned ${res.status}: ${await res.text()}`)
+      }
+      const payload = await res.json() as { results?: Array<{ data?: unknown[] }> }
+      return payload.results?.[0]?.data?.length ?? 0
+    }
+
+    if (options.vary) console.log(`Varying ${queries.length} distinct query shapes (stresses per-shape caches).`)
+
+    // Confirm the route works and report the payload size once.
+    const sampleRows = await runOnce()
+    console.log(`\nRoute POST ${BASE_PATH}/load  "${route.id}" — ${route.name}`)
+    console.log(`  returns ${sampleRows} rows · iterations=${options.iterations} warmup=${options.warmup} concurrency=${options.concurrency} mode=${options.mode}\n`)
+
+    const label = `route.${route.id}`
+    const wantTime = options.mode === 'time' || options.mode === 'all'
+    const wantCpu = options.mode === 'cpu' || options.mode === 'all'
+    const wantMem = options.mode === 'mem' || options.mode === 'all'
+
+    if (wantTime) {
+      if (options.concurrency > 1) {
+        // Throughput: keep `concurrency` requests in flight, measure wall time.
+        for (let i = 0; i < options.warmup; i++) await runOnce()
+        const start = process.hrtime.bigint()
+        let dispatched = 0
+        await Promise.all(
+          Array.from({ length: options.concurrency }, async () => {
+            while (dispatched < options.iterations) {
+              dispatched++
+              await runOnce()
+            }
+          })
+        )
+        const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6
+        const rps = Math.round((options.iterations / elapsedMs) * 1000)
+        console.log(`  Throughput (@${options.concurrency} concurrent): ${rps.toLocaleString()} req/s · ${options.iterations} reqs in ${elapsedMs.toFixed(0)}ms · ${(elapsedMs / options.iterations).toFixed(3)}ms avg`)
+      } else {
+        const t = await measureTiming(runOnce, options.iterations, options.warmup)
+        const ms = (us: number) => (us / 1000).toFixed(3)
+        console.log(`  Response time (${t.iterations} reqs): median ${ms(t.medianUs)}ms · mean ${ms(t.meanUs)}ms · p95 ${ms(t.p95Us)}ms · p99 ${ms(t.p99Us)}ms · ${t.opsPerSec.toLocaleString()} req/s`)
+      }
+    }
+
+    if (wantCpu) {
+      for (let i = 0; i < options.warmup; i++) await runOnce()
+      const profile = await profileCpu(label, runOnce, options.iterations)
+      const { totalMs, idleMs, activeMs, frames } = summarizeCpuProfile(profile, options.top)
+      const idlePct = totalMs > 0 ? (idleMs / totalMs) * 100 : 0
+      console.log(`\n  CPU profile → ${PROFILES_DIR}/${label}.cpuprofile  (${totalMs.toFixed(0)}ms wall · ${activeMs.toFixed(0)}ms active CPU · ${idlePct.toFixed(0)}% idle)`)
+      console.log(`  Top ${frames.length} frames by self time (share of active CPU):`)
+      console.log(`  ${'self'.padStart(9)}  ${'share'.padStart(6)}  frame`)
+      console.log(`  ${'-'.repeat(72)}`)
+      for (const f of frames) {
+        console.log(`  ${`${f.selfMs.toFixed(1)}ms`.padStart(9)}  ${`${(f.share * 100).toFixed(1)}%`.padStart(6)}  ${f.label}`)
+      }
+    }
+
+    if (wantMem) {
+      for (let i = 0; i < options.warmup; i++) await runOnce()
+      const mem = await measureMemory(label, runOnce, options.iterations)
+      console.log(`\n  Memory: retained ${fmtBytes(mem.retainedBytes)} total · peak heap ${fmtBytes(mem.peakBytes)}${mem.gcAvailable ? '' : ' (no --expose-gc)'}`)
+      console.log(`  Growth curve (post-GC retained vs baseline):`)
+      for (const c of mem.checkpoints) {
+        console.log(`    after ${String(c.atIteration).padStart(6)} reqs: ${fmtBytes(c.retainedBytes).padStart(9)}`)
+      }
+      const slope = mem.steadyStatePerIterationBytes
+      // A few bytes/req is GC jitter; flag a sustained climb in the back half.
+      const leaking = slope > 64
+      console.log(`  Steady-state slope (2nd half): ${slope >= 0 ? '+' : ''}${slope.toFixed(1)} B/req → ${leaking ? '⚠ GROWING (possible leak)' : 'stable (warmup only, no leak)'}`)
+    }
+
+    console.log(`\nDone.`)
+  } finally {
+    close()
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error('Route profiling failed:', error)
+    process.exit(1)
+  })

--- a/perf/route-profile.ts
+++ b/perf/route-profile.ts
@@ -211,22 +211,43 @@ async function main(): Promise<void> {
     const headers = { 'Content-Type': 'application/json' }
     let cursor = 0
 
-    // One real round-trip through the route handler. Validates status + payload
-    // so we never profile an error path, and returns the row count.
-    const runOnce: RunOnce = async () => {
+    const requestLoadRoute = async (): Promise<Response> => {
       const body = bodies[cursor++ % bodies.length]
       const res = await app.request(`${BASE_PATH}/load`, { method: 'POST', headers, body })
       if (res.status !== 200) {
         throw new Error(`Route returned ${res.status}: ${await res.text()}`)
       }
-      const payload = await res.json() as { results?: Array<{ data?: unknown[] }> }
-      return payload.results?.[0]?.data?.length ?? 0
+      return res
+    }
+
+    const countRowsFromPayload = (payload: unknown): number => {
+      if (typeof payload !== 'object' || payload === null || !('results' in payload) || !Array.isArray(payload.results)) {
+        return 0
+      }
+      const [firstResult] = payload.results
+      if (typeof firstResult !== 'object' || firstResult === null || !('data' in firstResult) || !Array.isArray(firstResult.data)) {
+        return 0
+      }
+      return firstResult.data.length
+    }
+
+    // Parse once outside the measured loop so profiler output excludes client-side
+    // Response.json()/JSON.parse work. The measured run still consumes the body to
+    // force response serialization, but only validates status and byte payload size.
+    const validateSample = async (): Promise<number> => {
+      const text = await (await requestLoadRoute()).text()
+      return countRowsFromPayload(JSON.parse(text))
+    }
+
+    const runOnce: RunOnce = async () => {
+      const text = await (await requestLoadRoute()).text()
+      return text.length
     }
 
     if (options.vary) console.log(`Varying ${queries.length} distinct query shapes (stresses per-shape caches).`)
 
     // Confirm the route works and report the payload size once.
-    const sampleRows = await runOnce()
+    const sampleRows = await validateSample()
     console.log(`\nRoute POST ${BASE_PATH}/load  "${route.id}" — ${route.name}`)
     console.log(`  returns ${sampleRows} rows · iterations=${options.iterations} warmup=${options.warmup} concurrency=${options.concurrency} mode=${options.mode}\n`)
 

--- a/perf/runner.ts
+++ b/perf/runner.ts
@@ -28,22 +28,26 @@ export interface RunnerOptions {
   iterations: number
 }
 
-export async function runBenchmark(
+/**
+ * Resolve the security context a benchmark runs under (its override, or org1 —
+ * the large benchmarked organisation).
+ */
+export function resolveSecurityContext(def: BenchmarkDef): SecurityContext {
+  return def.securityContext ?? testSecurityContexts.org1
+}
+
+/**
+ * Build the single-execution thunk for a benchmark: one `runOnce()` call drives
+ * the exact execution path the benchmark's `mode` selects. Shared by the timing
+ * runner and the profiler so both measure identical work. Returns the row count
+ * produced (0 for dryRun).
+ */
+export function makeRunOnce(
   def: BenchmarkDef,
   ctx: RunnerContext,
-  options: RunnerOptions
-): Promise<BenchmarkResult> {
-  const securityContext: SecurityContext = def.securityContext ?? testSecurityContexts.org1
-  const base: Omit<BenchmarkResult, 'stats' | 'samples' | 'rows'> = {
-    id: def.id,
-    name: def.name,
-    category: def.category,
-    mode: def.mode,
-    iterations: options.iterations,
-    warmup: options.warmup
-  }
-
-  const runOnce = async (): Promise<number> => {
+  securityContext: SecurityContext = resolveSecurityContext(def)
+): () => Promise<number> {
+  return async (): Promise<number> => {
     switch (def.mode) {
       case 'dryRun': {
         await ctx.executor.dryRunSQL(ctx.cubes, def.query, securityContext)
@@ -63,6 +67,24 @@ export async function runBenchmark(
       }
     }
   }
+}
+
+export async function runBenchmark(
+  def: BenchmarkDef,
+  ctx: RunnerContext,
+  options: RunnerOptions
+): Promise<BenchmarkResult> {
+  const securityContext: SecurityContext = resolveSecurityContext(def)
+  const base: Omit<BenchmarkResult, 'stats' | 'samples' | 'rows'> = {
+    id: def.id,
+    name: def.name,
+    category: def.category,
+    mode: def.mode,
+    iterations: options.iterations,
+    warmup: options.warmup
+  }
+
+  const runOnce = makeRunOnce(def, ctx, securityContext)
 
   try {
     let rows = 0

--- a/src/server/executors/sqlite-executor.ts
+++ b/src/server/executors/sqlite-executor.ts
@@ -17,11 +17,11 @@ export class SQLiteExecutor extends BaseDatabaseExecutor {
       // This is a Drizzle query object, execute it directly
       const result = await query.execute()
       if (Array.isArray(result)) {
-        return result.map(row => this.convertNumericFields(row, numericFields)) as T
+        return this.convertNumericFieldsInPlace(result, numericFields) as T
       }
       return result as T
     }
-    
+
     // SQLite is synchronous, but we wrap in Promise for consistency
     try {
       // For SQLite with better-sqlite3, we need to execute through the Drizzle instance
@@ -29,7 +29,7 @@ export class SQLiteExecutor extends BaseDatabaseExecutor {
       if (this.db.all) {
         const result = this.db.all(query)
         if (Array.isArray(result)) {
-          return result.map(row => this.convertNumericFields(row, numericFields)) as T
+          return this.convertNumericFieldsInPlace(result, numericFields) as T
         }
         return result as T
       } else if (this.db.run) {
@@ -45,22 +45,29 @@ export class SQLiteExecutor extends BaseDatabaseExecutor {
   }
 
   /**
-   * Convert numeric string fields to numbers (only for measure fields)
+   * Convert numeric string fields to numbers (only for measure fields), in place.
+   *
+   * Hot path for large result sets: this runs once per returned row. Rather than
+   * rebuild a fresh object per row (Object.entries + full-key copy), we mutate
+   * the driver-produced row — which we exclusively own — touching only the
+   * measure columns. Dimensions/time dimensions keep their original types.
+   * When there are no numeric fields, the rows are returned untouched.
    */
-  private convertNumericFields(row: any, numericFields?: string[]): any {
-    if (!row || typeof row !== 'object') return row
-    
-    const converted: any = {}
-    for (const [key, value] of Object.entries(row)) {
-      // Only convert measure fields to numbers
-      // Dimensions and time dimensions should keep their original types
-      if (numericFields && numericFields.includes(key)) {
-        converted[key] = this.coerceToNumber(value)
-      } else {
-        converted[key] = value
+  private convertNumericFieldsInPlace(rows: any[], numericFields?: string[]): any[] {
+    if (!numericFields || numericFields.length === 0) return rows
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i]
+      if (!row || typeof row !== 'object') continue
+      for (const key of numericFields) {
+        const value = row[key]
+        // Skip absent keys and values already numeric (the common case — SQLite
+        // returns INTEGER/REAL columns as JS numbers, so no coercion is needed).
+        if (value != null && typeof value !== 'number') {
+          row[key] = this.coerceToNumber(value)
+        }
       }
     }
-    return converted
+    return rows
   }
 
   /**


### PR DESCRIPTION
## What

Adds a profiling layer on top of the existing `perf/` timing suite — built entirely on Node's bundled inspector (**no new runtime deps**) — plus one profiler-driven optimization to the SQLite executor.

### Profiling harness
- **`perf/profiler.ts`** — inspector wrappers: CPU profiles (`.cpuprofile` + a terminal hot-frame table that splits **idle/IO vs active CPU**), allocation profiles (`.heapprofile`), high-resolution **timing** (µs), and **memory-growth sampling** (post-GC checkpoints + a second-half least-squares slope to distinguish a real leak from one-time warmup).
- **`perf/profile.ts`** (`npm run perf:profile`) — in-process profiling of the query engine by benchmark id/mode (`cpu|alloc|mem|time|all`).
- **`perf/route-profile.ts`** (`npm run perf:route`) — profiles the **real HTTP `/load` route** in-process via the Hono adapter over **SQLite** (synchronous, **0% idle** — every frame is real request work). Supports throughput (`--concurrency`), leak checks (`--mode=mem` with a growth curve), and `--vary` to cycle distinct query shapes and stress per-shape caches.
- **`perf/runner.ts`** — extracted a shared `makeRunOnce` so the profiler and the timing suite drive the **identical** execution path.

### Optimization
Real-route profiling showed result-row handling dominates large-payload responses. `convertNumericFields` in the SQLite executor rebuilt **every** result row via a full `Object.entries` + key copy. Reworked it to coerce **only** the numeric measure columns **in place** (rows are freshly driver-produced and exclusively owned), skipping the work entirely when there are no numeric fields.

- **~5% faster** on a 5000-row response (`load.ungrouped`: 7.45ms → 7.09ms median).
- Behavior-preserving; the full **SQLite suite (2348 tests) stays green**.

## Findings (from the harness)
- **Compile path** is microseconds (~97µs for a complex multi-cube query) — not worth optimizing.
- **Slow queries** in the timing suite (retention 155ms, count-distinct 72ms, time-series ~55ms) are **98–100% idle** — Postgres executing heavy SQL, not CPU. No JS optimization moves them.
- **Memory** across both fixed and **96 varied query shapes over 10k requests** is **flat** — no leaks. Retained heap plateaus after warmup; the transient peak (~150 MB on a 5000-row response) scales with payload size and is reclaimed by GC.

Docs: `perf/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)