### PR TITLE
fix(client): export ChartProps and ColorPalette from public entries

### DIFF
--- a/src/client/charts.ts
+++ b/src/client/charts.ts
@@ -60,7 +60,9 @@ export {
 export type {
   ChartType,
   ChartAxisConfig,
-  ChartDisplayConfig
+  ChartDisplayConfig,
+  ChartProps,
+  ColorPalette
 } from './types.js'
 
 // Chart configuration types

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -256,6 +256,8 @@ export type {
   BuiltInChartType,
   ChartAxisConfig,
   ChartDisplayConfig,
+  ChartProps,
+  ColorPalette,
   CubeQuery,
   CubeQueryOptions,
   CubeApiOptions,


### PR DESCRIPTION
The [chart plugins docs](https://www.drizzle-cube.dev/client/chart-plugins/) open with:

```ts
import type { ChartProps } from 'drizzle-cube/client'
```

That import doesn't resolve. `ChartProps` is declared in `src/client/types.ts` and used by all 27 built-in charts, but it was never re-exported from either public entry — so the documented plugin-author surface is unreachable from outside the package.

Same for the CLI: `npx drizzle-cube charts init` scaffolds a component whose first line is that exact import (`src/cli/commands/charts.ts`), so every generated custom chart fails to typecheck out of the box.

## Fix

Add `ChartProps` to the `./types.js` re-export block in both entries:
- `src/client/index.ts` → `drizzle-cube/client`
- `src/client/charts.ts` → `drizzle-cube/client/charts`

`ColorPalette` comes along with it — `ChartProps.colorPalette?: ColorPalette` is part of the interface, and without the type exported a plugin author can't name the parameter they're handed. It was already re-exported from `types.ts`, just not from the barrels.

Types only; no runtime change and no behaviour change.

Verified in the emitted declarations after `npm run build:client`:

```
dist/client/index.d.ts:58:  export type { …, ChartDisplayConfig, ChartProps, ColorPalette, CubeQuery, … } from './types.js';
dist/client/charts.d.ts:16: export type { ChartType, ChartAxisConfig, ChartDisplayConfig, ChartProps, ColorPalette } from './types.js';
```

## Gate
`npm run typecheck` ✅ · `npm run lint` ✅ · `npm run test:client` ✅ 5900 tests · `npm run build:client` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
