### PR TITLE
fix(cli): make `charts init --from <type>` work from the published package

### DIFF
--- a/src/cli/commands/charts.ts
+++ b/src/cli/commands/charts.ts
@@ -7,9 +7,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { parseArgs } from 'node:util'
+import type { BuiltInChartType } from '../../client/types.js'
 
-// Built-in chart types with descriptions
-const BUILT_IN_CHARTS: Record<string, string> = {
+// Built-in chart types with descriptions.
+// Typed against BuiltInChartType so adding a chart fails typecheck until it is
+// listed here — this catalogue drifted out of date once already.
+const BUILT_IN_CHARTS: Record<BuiltInChartType, string> = {
   bar: 'Bar chart — compare values across categories',
   line: 'Line chart — show trends over time',
   area: 'Area chart — line chart with filled areas',
@@ -24,10 +27,13 @@ const BUILT_IN_CHARTS: Record<string, string> = {
   kpiNumber: 'KPI number — single metric display',
   kpiDelta: 'KPI delta — metric with change indicator',
   kpiText: 'KPI text — text-based metric',
+  markdown: 'Markdown — rich text block',
   funnel: 'Funnel chart — conversion funnel visualization',
   sankey: 'Sankey diagram — flow visualization',
   sunburst: 'Sunburst chart — hierarchical pie chart',
   heatmap: 'Heatmap — color-coded matrix',
+  retentionHeatmap: 'Retention heatmap — cohort retention matrix',
+  retentionCombined: 'Retention combined — retention curve plus cohort matrix',
   boxPlot: 'Box plot — statistical distribution',
   waterfall: 'Waterfall chart — cumulative values',
   candlestick: 'Candlestick chart — financial OHLC data',
@@ -44,7 +50,7 @@ export function chartsList(): void {
   for (const [type, desc] of Object.entries(BUILT_IN_CHARTS)) {
     console.log(`  ${type.padEnd(maxLen + 2)} ${desc}`)
   }
-  console.log(`\nUse --from <type> with 'charts init' to copy a built-in as starting point.`)
+  console.log(`\nUse --from <type> with 'charts init' to start from a built-in.`)
   console.log(`Example: npx drizzle-cube charts init --from bar\n`)
 }
 
@@ -66,7 +72,7 @@ export function chartsInit(): void {
   const customName = values.name as string | undefined
 
   if (fromBuiltIn) {
-    if (!BUILT_IN_CHARTS[fromBuiltIn]) {
+    if (!Object.hasOwn(BUILT_IN_CHARTS, fromBuiltIn)) {
       console.error(`\nUnknown chart type: "${fromBuiltIn}"`)
       console.error(`Run 'npx drizzle-cube charts list' to see available types.\n`)
       process.exit(1)
@@ -116,80 +122,47 @@ Next steps:
 `)
 }
 
+/**
+ * Scaffold a custom chart that starts out as a built-in.
+ *
+ * The scaffold *wraps* the built-in through the public API rather than copying
+ * its source: built-in charts import internals (`useTranslation`, `pivotUtils`,
+ * per-chart sibling helpers) that `drizzle-cube/client` does not export, and the
+ * published package ships `dist/` only — so a copy would neither be available
+ * nor compile. Wrapping renders the real chart from day one and leaves the user
+ * a component body to replace at their own pace.
+ */
 function scaffoldFromBuiltIn(chartType: string, outputDir: string, customName?: string): void {
   const pascalType = chartType.charAt(0).toUpperCase() + chartType.slice(1)
   const name = customName || `Custom${pascalType}Chart`
   const customType = camelCase(name)
 
-  // Find the source files
-  const sourceDir = findPackageChartsDir()
-  if (!sourceDir) {
-    console.log(`
-Could not find drizzle-cube chart source files.
-Generating a template based on the ${chartType} chart instead.
-`)
-    scaffoldExample(outputDir, name)
-    return
-  }
-
-  // Map chart type to file names
-  const fileMap: Record<string, string> = {
-    bar: 'BarChart', line: 'LineChart', area: 'AreaChart', pie: 'PieChart',
-    scatter: 'ScatterChart', bubble: 'BubbleChart', radar: 'RadarChart',
-    radialBar: 'RadialBarChart', treemap: 'TreeMapChart', table: 'DataTable',
-    activityGrid: 'ActivityGridChart', kpiNumber: 'KpiNumber', kpiDelta: 'KpiDelta',
-    kpiText: 'KpiText', funnel: 'FunnelChart', sankey: 'SankeyChart',
-    sunburst: 'SunburstChart', heatmap: 'HeatMapChart', boxPlot: 'BoxPlotChart',
-    waterfall: 'WaterfallChart', candlestick: 'CandlestickChart',
-    gauge: 'GaugeChart', measureProfile: 'MeasureProfileChart',
-  }
-
-  const fileName = fileMap[chartType]
-  if (!fileName) {
-    console.error(`No file mapping for chart type: ${chartType}`)
-    scaffoldExample(outputDir, name)
-    return
-  }
-
-  const componentSource = path.join(sourceDir, `${fileName}.tsx`)
-  const configSource = path.join(sourceDir, `${fileName}.config.ts`)
-
   ensureDir(outputDir)
 
-  // Copy and rewrite component
-  if (fs.existsSync(componentSource)) {
-    const content = fs.readFileSync(componentSource, 'utf-8')
-    const rewritten = rewriteImports(content)
-    const componentPath = path.join(outputDir, `${name}.tsx`)
-    writeIfNotExists(componentPath, rewritten)
-  }
+  const componentPath = path.join(outputDir, `${name}.tsx`)
+  writeIfNotExists(componentPath, generateBuiltInWrapper(name, chartType))
 
-  // Copy and rewrite config
-  if (fs.existsSync(configSource)) {
-    const content = fs.readFileSync(configSource, 'utf-8')
-    const rewritten = rewriteImports(content)
-    const configPath = path.join(outputDir, `${name}.config.ts`)
-    writeIfNotExists(configPath, rewritten)
-  }
+  const configPath = path.join(outputDir, `${name}.config.ts`)
+  writeIfNotExists(configPath, generateBuiltInConfig(name, customType, chartType))
 
-  // Write registration example
   const indexPath = path.join(outputDir, 'index.ts')
-  writeIfNotExists(indexPath, generateRegistrationFromBuiltIn(name, customType, chartType, fileName))
+  writeIfNotExists(indexPath, generateRegistrationExample(name, customType))
 
   console.log(`
-Chart copied from built-in '${chartType}' to ${outputDir}/
+Chart plugin based on built-in '${chartType}' scaffolded in ${outputDir}/
 
 Files created:
-  ${path.join(outputDir, `${name}.tsx`)}        — Chart component (copied from ${fileName})
-  ${path.join(outputDir, `${name}.config.ts`)}   — Chart configuration
-  ${path.join(outputDir, 'index.ts')}            — Registration example
+  ${componentPath}        — Chart component (renders the built-in '${chartType}')
+  ${configPath}   — Chart configuration (starts from the built-in's)
+  ${indexPath}            — Registration example
 
 The chart is registered as type '${customType}' (not '${chartType}'), so
 the built-in is preserved. Change the type to '${chartType}' to override it.
 
 Next steps:
-  1. Customize the component and config
-  2. Register in your app:
+  1. Replace the <LazyChart> body in ${name}.tsx with your own rendering
+  2. Adjust drop zones / display options in ${name}.config.ts
+  3. Register in your app:
 
      import { customCharts } from '${outputDir}'
 
@@ -340,32 +313,45 @@ export const customCharts: ChartDefinition[] = [
 `
 }
 
-function generateRegistrationFromBuiltIn(name: string, customType: string, _builtInType: string, fileName: string): string {
-  // Try to guess the config export name from the file name
-  const configExportName = fileName.charAt(0).toLowerCase() + fileName.slice(1) + 'Config'
-
-  return `import type { ChartDefinition } from 'drizzle-cube/client'
-import ${name} from './${name}'
-import { ${configExportName} } from './${name}.config'
+function generateBuiltInWrapper(name: string, builtInType: string): string {
+  return `import React from 'react'
+import { LazyChart } from 'drizzle-cube/client'
+import type { ChartProps } from 'drizzle-cube/client'
 
 /**
- * Custom chart definitions to pass to CubeProvider.
+ * ${name} — starts out rendering the built-in '${builtInType}' chart.
  *
- * Usage:
- *   import { customCharts } from './charts.js'
- *
- *   <CubeProvider customCharts={customCharts} ...>
- *     <App />
- *   </CubeProvider>
+ * Built-in charts are not copied into your project: they depend on internals
+ * that are not part of the public API. Instead this delegates to the real
+ * '${builtInType}' chart, so it works as-is. Customize by wrapping it (extra
+ * chrome, transformed \`data\`/\`chartConfig\`) or by replacing the body entirely
+ * with your own rendering — the ChartProps contract stays the same either way.
  */
-export const customCharts: ChartDefinition[] = [
-  {
-    type: '${customType}',
-    label: ${configExportName}.label || '${name.replace(/([A-Z])/g, ' $1').trim()}',
-    config: ${configExportName},
-    component: ${name},
-  },
-]
+const ${name} = React.memo(function ${name}(props: ChartProps) {
+  return <LazyChart chartType="${builtInType}" {...props} />
+})
+
+export default ${name}
+`
+}
+
+function generateBuiltInConfig(name: string, chartType: string, builtInType: string): string {
+  return `import { getBuiltInChartConfig } from 'drizzle-cube/client'
+import type { ChartTypeConfig } from 'drizzle-cube/client'
+
+/**
+ * Configuration for ${name}.
+ *
+ * Starts from the built-in '${builtInType}' config so the drop zones and display
+ * options match the chart being rendered. Override any field below, or drop the
+ * spread and declare your own \`dropZones\` / \`displayOptionsConfig\` once this
+ * chart diverges from the built-in.
+ */
+export const ${chartType}Config: ChartTypeConfig = {
+  ...getBuiltInChartConfig('${builtInType}'),
+  label: '${name.replace(/([A-Z])/g, ' $1').trim()}',
+  description: 'A custom chart based on the built-in ${builtInType} chart',
+}
 `
 }
 
@@ -391,60 +377,3 @@ function writeIfNotExists(filePath: string, content: string): void {
   fs.writeFileSync(filePath, content, 'utf-8')
 }
 
-/**
- * Try to find the chart component source directory from the installed package.
- */
-function findPackageChartsDir(): string | null {
-  // Try to find the source files relative to this CLI script
-  const candidates = [
-    // When running from the package's dist/cli directory
-    path.resolve(__dirname, '..', '..', 'src', 'client', 'components', 'charts'),
-    // When running from node_modules
-    path.resolve(__dirname, '..', 'client', 'components', 'charts'),
-  ]
-
-  for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
-      return candidate
-    }
-  }
-
-  // Try to resolve from node_modules
-  try {
-    const pkgPath = require.resolve('drizzle-cube/package.json')
-    const pkgDir = path.dirname(pkgPath)
-    const chartsDir = path.join(pkgDir, 'src', 'client', 'components', 'charts')
-    if (fs.existsSync(chartsDir)) {
-      return chartsDir
-    }
-  } catch {
-    // Not installed as dependency
-  }
-
-  return null
-}
-
-/**
- * Rewrite internal drizzle-cube imports to use the public package imports.
- */
-function rewriteImports(content: string): string {
-  return content
-    // Chart utility imports
-    .replace(/from\s+['"]\.\.\/\.\.\/charts\/chartConfigs['"]/g, "from 'drizzle-cube/client'")
-    .replace(/from\s+['"]\.\.\/\.\.\/charts\/[^'"]+['"]/g, "from 'drizzle-cube/client'")
-    // Type imports
-    .replace(/from\s+['"]\.\.\/\.\.\/types['"]/g, "from 'drizzle-cube/client'")
-    // Hooks
-    .replace(/from\s+['"]\.\.\/\.\.\/hooks\/[^'"]+['"]/g, "from 'drizzle-cube/client'")
-    // Icons
-    .replace(/from\s+['"]\.\.\/\.\.\/icons['"]/g, "from 'drizzle-cube/client'")
-    .replace(/from\s+['"]\.\.\/\.\.\/icons\/[^'"]+['"]/g, "from 'drizzle-cube/client'")
-    // Utils
-    .replace(/from\s+['"]\.\.\/\.\.\/utils\/[^'"]+['"]/g, "from 'drizzle-cube/client'")
-    // Shared
-    .replace(/from\s+['"]\.\.\/\.\.\/shared\/[^'"]+['"]/g, "from 'drizzle-cube/client'")
-    // Providers
-    .replace(/from\s+['"]\.\.\/\.\.\/providers\/[^'"]+['"]/g, "from 'drizzle-cube/client'")
-    // Relative chart component imports (e.g., from './ChartTooltip')
-    .replace(/from\s+['"]\.\/([^'"]+)['"]/g, "from 'drizzle-cube/client'")
-}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,7 @@
  *
  * Usage:
  *   npx drizzle-cube charts init               # Scaffold an example custom chart
- *   npx drizzle-cube charts init --from bar     # Copy a built-in chart as starting point
+ *   npx drizzle-cube charts init --from bar     # Start from a built-in chart
  *   npx drizzle-cube charts init -o ./my-charts # Custom output directory
  *   npx drizzle-cube charts list                # List available built-in chart types
  */
@@ -31,7 +31,7 @@ drizzle-cube charts
 
 Commands:
   drizzle-cube charts init             Scaffold a custom chart
-  drizzle-cube charts init --from bar  Copy a built-in chart as starting point
+  drizzle-cube charts init --from bar  Start from a built-in chart
   drizzle-cube charts init -o <dir>    Set output directory (default: ./src/charts)
   drizzle-cube charts list             List available built-in chart types
 `)

--- a/src/client/charts.ts
+++ b/src/client/charts.ts
@@ -60,7 +60,9 @@ export {
 export type {
   ChartType,
   ChartAxisConfig,
-  ChartDisplayConfig
+  ChartDisplayConfig,
+  ChartProps,
+  ColorPalette
 } from './types.js'
 
 // Chart configuration types

--- a/src/client/charts/chartConfigRegistry.ts
+++ b/src/client/charts/chartConfigRegistry.ts
@@ -72,12 +72,26 @@ const baseConfigs: Record<BuiltInChartType, ChartTypeConfig> = {
  * source of truth) laid over its full config shape. Drop zones / display options
  * stay here in full because the server agent reads them synchronously.
  */
-export const chartConfigRegistry: ChartConfigRegistry = Object.fromEntries(
+const builtInConfigs: ChartConfigRegistry = Object.fromEntries(
   (Object.keys(chartRegistry) as BuiltInChartType[]).map((type) => [
     type,
     composeChartConfig(chartRegistry[type], baseConfigs[type]),
   ])
 )
+
+export const chartConfigRegistry: ChartConfigRegistry = { ...builtInConfigs }
+
+/**
+ * The composed config of a built-in chart — the starting point for a custom
+ * chart that extends or wraps a built-in (see `drizzle-cube charts init --from`).
+ *
+ * Reads the built-in snapshot rather than the live registry, so a plugin that
+ * overrides the same type cannot change what this returns; the shallow copy
+ * keeps callers from mutating it by editing the object they get back.
+ */
+export function getBuiltInChartConfig(type: BuiltInChartType): ChartTypeConfig {
+  return { ...builtInConfigs[type] }
+}
 
 /**
  * Register a custom chart config into the registry.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -330,6 +330,7 @@ export type {
 // Chart plugin system
 export type { ChartDefinition } from './charts/chartPlugin.js'
 export { chartPluginRegistry } from './charts/chartPlugin.js'
+export { getBuiltInChartConfig } from './charts/chartConfigRegistry.js'
 
 // Utilities
 export { createDashboardLayout, formatChartData, highlightCodeBlocks } from './utils/index.js'

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -256,6 +256,8 @@ export type {
   BuiltInChartType,
   ChartAxisConfig,
   ChartDisplayConfig,
+  ChartProps,
+  ColorPalette,
   CubeQuery,
   CubeQueryOptions,
   CubeApiOptions,

--- a/tests/cli/charts-init.test.ts
+++ b/tests/cli/charts-init.test.ts
@@ -1,0 +1,112 @@
+/**
+ * DB-free CLI test.
+ *
+ * Lives in the `cli` vitest project (see vitest.config.ts): no Docker, no
+ * globalSetup, no database. Pure logic over a temp output dir, runs in
+ * milliseconds.
+ *
+ * Regression cover for `charts init --from <type>`: it used to try to copy the
+ * built-in's *source* out of the installed package. The published package ships
+ * `dist/` only, so nothing was ever copied — yet the command still printed
+ * "Chart copied…" and left an `index.ts` importing two files that did not exist.
+ * The scaffold now wraps the built-in through the public API instead.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { chartsInit } from '../../src/cli/commands/charts'
+
+let outDir: string
+
+/** Run `charts init` with the given argv tail, capturing stdout. */
+function runInit(...args: string[]): string {
+  const logged: string[] = []
+  vi.spyOn(console, 'log').mockImplementation((...parts: unknown[]) => {
+    logged.push(parts.map(String).join(' '))
+  })
+  vi.spyOn(process, 'argv', 'get').mockReturnValue(['node', 'drizzle-cube', ...args])
+  chartsInit()
+  return logged.join('\n')
+}
+
+beforeEach(() => {
+  outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-charts-init-'))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  fs.rmSync(outDir, { recursive: true, force: true })
+})
+
+describe('charts init --from <built-in> (DB-free CLI)', () => {
+  it('writes all three files without needing the package sources on disk', () => {
+    runInit('charts', 'init', '--from', 'table', '-o', outDir)
+
+    // The bug: only index.ts was written, referencing two files that never existed.
+    expect(fs.readdirSync(outDir).sort()).toEqual([
+      'CustomTableChart.config.ts',
+      'CustomTableChart.tsx',
+      'index.ts',
+    ])
+  })
+
+  it('emits only public drizzle-cube imports — no internal paths', () => {
+    runInit('charts', 'init', '--from', 'table', '-o', outDir)
+
+    for (const file of fs.readdirSync(outDir)) {
+      const source = fs.readFileSync(path.join(outDir, file), 'utf-8')
+      // Line-anchored so the usage example inside the doc comment is not matched.
+      const imports = [...source.matchAll(/^import .*from '([^']+)'/gm)].map(m => m[1])
+      for (const specifier of imports) {
+        // Sibling files in the scaffold are fine; anything else must be a
+        // public entry point. Internal paths ('../../types.js', './pivotUtils')
+        // are what made the old copied output uncompilable.
+        const isSibling = specifier.startsWith('./Custom')
+        const isPublic = specifier === 'react' || specifier.startsWith('drizzle-cube/')
+        expect(isSibling || isPublic, `${file} imports ${specifier}`).toBe(true)
+      }
+    }
+  })
+
+  it('wires the config, component and registration together consistently', () => {
+    runInit('charts', 'init', '--from', 'table', '-o', outDir)
+
+    const component = fs.readFileSync(path.join(outDir, 'CustomTableChart.tsx'), 'utf-8')
+    const config = fs.readFileSync(path.join(outDir, 'CustomTableChart.config.ts'), 'utf-8')
+    const index = fs.readFileSync(path.join(outDir, 'index.ts'), 'utf-8')
+
+    // Renders the real built-in rather than a stub.
+    expect(component).toContain(`<LazyChart chartType="table"`)
+    // Starts from the built-in's drop zones / display options.
+    expect(config).toContain(`getBuiltInChartConfig('table')`)
+    // The registration imports the name the config actually exports; the old
+    // generator guessed it from the source file name and got 'dataTableConfig'.
+    expect(config).toContain('export const customTableChartConfig')
+    expect(index).toContain('import { customTableChartConfig }')
+    // Registered under a new type so the built-in survives.
+    expect(index).toContain(`type: 'customTableChart'`)
+  })
+
+  it('honours --name', () => {
+    runInit('charts', 'init', '--from', 'bar', '-o', outDir, '--name', 'RevenueBars')
+
+    expect(fs.readdirSync(outDir).sort()).toEqual([
+      'RevenueBars.config.ts',
+      'RevenueBars.tsx',
+      'index.ts',
+    ])
+    expect(fs.readFileSync(path.join(outDir, 'RevenueBars.config.ts'), 'utf-8'))
+      .toContain(`getBuiltInChartConfig('bar')`)
+  })
+
+  it('rejects an unknown chart type instead of scaffolding something broken', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exited')
+    }) as never)
+
+    expect(() => runInit('charts', 'init', '--from', 'noSuchChart', '-o', outDir)).toThrow('exited')
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+})

--- a/tests/client/charts/chartRegistry.test.ts
+++ b/tests/client/charts/chartRegistry.test.ts
@@ -12,7 +12,12 @@ import { screen } from '@testing-library/react'
 import { createElement } from 'react'
 import { renderWithProviders } from '../../client-setup/test-utils'
 import { chartRegistry, composeChartConfig, getChartEntry } from '../../../src/client/charts/chartRegistry'
-import { chartConfigRegistry } from '../../../src/client/charts/chartConfigRegistry'
+import {
+  chartConfigRegistry,
+  getBuiltInChartConfig,
+  registerChartConfig,
+  unregisterChartConfig,
+} from '../../../src/client/charts/chartConfigRegistry'
 import { barChartConfig } from '../../../src/client/components/charts/BarChart.config'
 import {
   getChartConfigAsync,
@@ -406,5 +411,36 @@ describe('chartRegistry — icon resolution is import-order independent', () => 
     expect(icons.getChartTypeIcon('line')).toBe(icons.getIcon('chartLine'))
     expect(icons.getChartTypeIcon('line')).not.toBe(icons.getIcon('chartBar'))
     expect(icons.getChartTypeIcon('gauge')).toBe(icons.getIcon('chartGauge'))
+  })
+})
+
+describe('getBuiltInChartConfig — the base a scaffolded chart plugin spreads', () => {
+  afterEach(() => {
+    unregisterChartConfig('table')
+    chartConfigRegistry.table = getBuiltInChartConfig('table')
+  })
+
+  it('returns the built-in composed config, not an empty shell', () => {
+    // `drizzle-cube charts init --from table` emits a config that spreads this;
+    // an empty object there would silently ship a chart with no drop zones.
+    const config = getBuiltInChartConfig('table')
+
+    expect(config.label).toBe('chart.table.label')
+    expect(config.dropZones?.length).toBeGreaterThan(0)
+    expect(config.dropZones).toEqual(chartConfigRegistry.table.dropZones)
+  })
+
+  it('reads the built-in snapshot, so a plugin overriding the type cannot change it', () => {
+    registerChartConfig('table', { label: 'hijacked', dropZones: [] })
+
+    expect(chartConfigRegistry.table.label).toBe('hijacked')
+    expect(getBuiltInChartConfig('table').label).toBe('chart.table.label')
+  })
+
+  it('hands back a copy callers cannot mutate the registry through', () => {
+    const config = getBuiltInChartConfig('table')
+    config.label = 'mutated'
+
+    expect(getBuiltInChartConfig('table').label).toBe('chart.table.label')
   })
 })


### PR DESCRIPTION
> **Stacked on #1047.** That PR exports `ChartProps` / `ColorPalette`; the scaffold generated here imports them, so this branch is rebased on it and the diff below shows only the CLI change. Merge #1047 first.

## The bug

`npx drizzle-cube charts init --from table` reports success but only writes `index.ts`, which imports two files that were never created:

```
$ node node_modules/drizzle-cube/dist/cli/index.cjs charts init --from table -o ./src/charts
Chart copied from built-in 'table' to ./src/charts/
Files created:
  src/charts/CustomTableChart.tsx        — Chart component (copied from DataTable)
  src/charts/CustomTableChart.config.ts   — Chart configuration
  src/charts/index.ts            — Registration example

$ ls src/charts/
index.ts
```

## Why — it is both the packaging *and* real bugs

`--from` copied the built-in's **source** out of the installed package and regex-rewrote its imports. That path cannot work:

1. **The package ships `dist/` only.** `findPackageChartsDir()` matched `dist/client/components/charts`, which contains `.d.ts` files and no `.tsx` / `.config.ts`. Both `fs.existsSync` guards failed, nothing was copied — and `scaffoldFromBuiltIn` printed its success message unconditionally.
2. **`require.resolve('drizzle-cube/package.json')`**, the last fallback, always threw `ERR_PACKAGE_PATH_NOT_EXPORTED` — `./package.json` is not in `exports`.
3. **Copies could not compile even with sources present.** Built-in charts import internals `drizzle-cube/client` does not export (`useTranslation`, `pivotUtils`, `formatAxisValue`, per-chart sibling helpers such as `./BarChart.helpers`). The `'../../types.js'` rule never matched, because every rewrite rule was written without the `.js` extension the sources actually use. And the registration guessed the config export name from the source filename, emitting `import { dataTableConfig } from './CustomTableChart.config'`.

So it is not only the npm packaging — copying built-in source was never viable, in-repo included.

## The fix

`--from <type>` now **wraps** the built-in through the public API instead of copying it. The component renders the real chart via `LazyChart`; the config spreads the built-in's own drop zones and display options. Identical behaviour from npm and from the repo, and `findPackageChartsDir` / `rewriteImports` / the filename map are deleted (net −142 lines in the CLI).

```tsx
const CustomTableChart = React.memo(function CustomTableChart(props: ChartProps) {
  return <LazyChart chartType="table" {...props} />
})
```
```ts
export const customTableChartConfig: ChartTypeConfig = {
  ...getBuiltInChartConfig('table'),
  label: 'Custom Table Chart',
  description: 'A custom chart based on the built-in table chart',
}
```

Picked up along the way:

- **`getBuiltInChartConfig()`** reads a built-in snapshot rather than the live, plugin-mutable `chartConfigRegistry`, and returns a copy, so a plugin overriding `table` cannot change what a scaffold spreads.
- **`BUILT_IN_CHARTS` is typed `Record<BuiltInChartType, string>`** so the catalogue cannot silently drift again; adds the missing `markdown`, `retentionHeatmap`, `retentionCombined`.
- CLI help no longer says "copy a built-in".

## Verification

Scaffolded from a **dist-only** package (`files: ["dist/", …]`, exactly what npm publishes) into a standalone consumer project with its own tsconfig, for `table`, `bar`, `kpiNumber`, `markdown`, `sankey`, `gauge` and the generic template — `tsc --noEmit` exits 0 on all of them. Before this change, two of three files were absent and the third imported them.

- `npm run test:cli` — 6 passed (new `tests/cli/charts-init.test.ts` covers the missing files, internal-import leakage, config/registration wiring, `--name`, unknown type)
- `npm run test:client` — 5903 passed (adds 3 cases for `getBuiltInChartConfig`)
- `npm run lint && npm run typecheck && npm run build && npm run check:exports` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)