### PR TITLE
docs: 0.8 release page + link fixes missed by the #1192 squash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ npm run test:teardown # Stop and remove test database containers
 > [!TIP]
 > The dev server and test databases use completely separate Docker containers and ports, so you can run `npm run dev` and `npm test` at the same time. This is useful for observing your changes in the browser while verifying they pass tests.
 
-**No Docker available?** If you're working in a container, a sandbox, or any environment where you can't start Docker, run the DB-free suites instead of `npm test` — `npm run test:sqlite`, `npm run test:client`, `npm run test:cli`, plus `npm run lint` and `npm run typecheck`. `test:sqlite` runs the same server suite against in-process SQLite, so it's a real verification signal rather than a subset. See [CLAUDE.md → Testing in a constrained environment](CLAUDE.md#testing-in-a-constrained-environment-ci-sandboxes-agents-containers).
+**No Docker available?** If you're working in a container, a sandbox, or any environment where you can't start Docker, run the DB-free suites instead of `npm test` — `npm run test:sqlite`, `npm run test:client`, `npm run test:cli`, plus `npm run lint` and `npm run typecheck`. `test:sqlite` runs the same server suite against in-process SQLite, so it's a real verification signal rather than a subset. See [CLAUDE.md → Testing in a constrained environment](https://github.com/cliftonc/drizzle-cube/blob/main/CLAUDE.md#testing-in-a-constrained-environment-ci-sandboxes-agents-containers).
 
 ## <a name="commit-message-guidelines"></a> Commit message guidelines
 

--- a/docs/migrating-to-0.8.md
+++ b/docs/migrating-to-0.8.md
@@ -1,14 +1,45 @@
-# Migrating to 0.8
+# Release 0.8 — per-tenant cube definitions
 
-0.8 makes cube definitions resolvable **per tenant**. The mechanism is described in
-[`per-tenant-cube-sets.md`](./per-tenant-cube-sets.md); this page is only the
-breaking changes and what to do about them.
+0.8 makes cube definitions resolvable **per tenant**. This page is both the
+release summary and the upgrade guide.
 
 **If you have a single-tenant deployment, nothing behaves differently.** With no
 `contextToCubeSetId` configured, every security context resolves to the base set
-exactly as before. Only signatures moved.
+exactly as before. Only signatures moved — see [Breaking
+changes](#breaking-changes) for the mechanical edits your compiler will point at.
 
-## 1. `securityContext` is required on every cube-resolving method
+## What's new
+
+**Per-tenant cube sets.** One `SemanticLayerCompiler` can now serve different
+cube definitions to different tenants — drizzle-cube's equivalent of Cube's
+`COMPILE_CONTEXT`. Map a security context to a set with `contextToCubeSetId`,
+and register one set per tenant at boot with `registerCubeSet`. Sets are merged
+over the shared base set at registration time, so requests read a precomputed
+map. Full guide: [Per-Tenant Cube
+Sets](https://www.drizzle-cube.dev/semantic-layer/cube-sets/).
+
+**Generated dimensions for user-defined attributes (EAV).**
+`buildAttributeDimensions()` turns rows in an attribute/value junction table
+into ordinary dimensions, so filtering, sorting, drill-down and export all work
+through paths that already exist. Member names derive from the attribute **id**,
+so renaming an attribute updates every header without breaking saved dashboards.
+
+**Tolerant casts across all 7 engines.** `tryCastToType` — and `ctx.tryCast` on
+`QueryContext` — yield `NULL` for unparseable input instead of failing the whole
+query on Postgres or silently returning `0` on MySQL/SQLite. Essential when a
+free-text column holds numbers for some rows and `n/a` for others.
+
+**`shown: false` is honoured.** Previously declared and read nowhere. It now
+omits a dimension or measure from `/meta`, the client field picker and AI
+prompts, while leaving it fully queryable — matching Cube.js semantics.
+
+**Safer defaults.** Every REST response now sets `Cache-Control: private,
+no-store`, and query cache keys carry a cube-set component so results can
+neither cross tenants nor survive a definition change.
+
+## Breaking changes
+
+### 1. `securityContext` is required on every cube-resolving method
 
 Because cube contents can now differ per tenant, these methods take a required
 `SecurityContext`:
@@ -51,7 +82,7 @@ Registration is unaffected: `registerCube`, `registerCubeSet`,
 `unregisterCubeSet` and `getCubeSetStats` take no context, because registration
 defines tenancy rather than operating within it.
 
-## 2. `/meta` is tenant-scoped
+### 2. `/meta` is tenant-scoped
 
 **Users of the Hono, Express, Fastify and Next.js adapters need no code change** —
 `extractSecurityContext` is already in your options and the adapter now passes it
@@ -65,7 +96,7 @@ to `/meta` as it always has to every other route. Two things change anyway:
   for every caller. A shared cache or CDN keyed on URL alone would now
   cross-serve one tenant's cube list to another.
 
-## 3. Every REST response sets `Cache-Control: private, no-store`
+### 3. Every REST response sets `Cache-Control: private, no-store`
 
 `/meta`, `/load`, `/sql`, `/dry-run`, `/batch` and `/explain` previously carried
 no `Cache-Control` at all, which permits heuristic caching of tenant data by a
@@ -74,13 +105,13 @@ shared cache. They now set `private, no-store`.
 Client-side caching is unaffected: the drizzle-cube React client caches through
 TanStack Query's `staleTime`, not the HTTP cache.
 
-## 4. `HttpPort.setHeader` is required — third-party adapters only
+### 4. `HttpPort.setHeader` is required — third-party adapters only
 
 If you have written your own framework adapter, `setHeader(name, value)` moved
 from `McpHttpPort` to the base `HttpPort` and is now required, so REST responses
 can carry the cache header. All four first-party adapters already implemented it.
 
-## 5. Changed handler signatures
+### 5. Changed handler signatures
 
 Only relevant if you call these directly rather than through an adapter. Each
 takes the security context as its second argument, matching `handleLoad`:
@@ -97,7 +128,7 @@ resolvable security context now return an error result rather than answering
 from the base set, and MCP resources are resolved per request instead of being
 built once at handler construction.
 
-## 6. `QueryContext` gains `cast` and `tryCast`
+### 6. `QueryContext` gains `cast` and `tryCast`
 
 Cube `sql` functions now receive engine-portable cast helpers:
 
@@ -110,7 +141,7 @@ the query (Postgres) or silently returning `0` (MySQL/SQLite). Both are required
 fields, so if you construct a `QueryContext` by hand — typically in tests — you
 must supply them.
 
-## 7. `shown: false` is now honoured
+### 7. `shown: false` is now honoured
 
 `shown: false` on a dimension or measure previously did nothing. It now omits
 the member from `/meta`, the client field picker and AI prompts. The member

--- a/docs/per-tenant-cube-sets.md
+++ b/docs/per-tenant-cube-sets.md
@@ -13,7 +13,7 @@ The motivating case is user-defined attributes (EAV): an admin adds a "Health"
 attribute for their organisation, it becomes a dimension, and no other tenant
 should see it.
 
-Upgrading an existing deployment? See [`migrating-to-0.8.md`](./migrating-to-0.8.md).
+Upgrading an existing deployment? See [Release 0.8](https://www.drizzle-cube.dev/guides/migrating-to-0-8/).
 
 ## The boot loop
 


### PR DESCRIPTION
Follow-up to #1192. Two commits landed on the branch **one and three minutes after** that PR was squash-merged, so they were not included:

- `docs: make the 0.8 migration guide double as the release page` (06:33:51) — merge was 06:32:30
- `docs: absolute CLAUDE.md link in CONTRIBUTING` (06:35:54)

Markdown only; no code changes.

## Why this matters beyond tidiness

Both files are **published verbatim on drizzle-cube.dev** by the help site's `sync-external-content.js`:

| Source | Published as |
|---|---|
| `docs/migrating-to-0.8.md` | `guides/migrating-to-0-8` |
| `CONTRIBUTING.md` | `contributing/guidelines` |

[drizzle-cube-help#57](https://github.com/cliftonc/drizzle-cube-help/pull/57) adds those synced pages, generated from these newer versions. Without this PR, the next sync run against `main` would regenerate the **older** content and silently revert them.

## What's in it

**`docs/migrating-to-0.8.md` becomes a release page, not just an upgrade checklist.** It now opens with a *What's new* summary — per-tenant cube sets, `buildAttributeDimensions`, tolerant casts across all 7 engines, the `shown` flag, and the safer cache defaults — followed by the seven numbered breaking changes. Someone arriving from a release announcement asking "what did I get" is served, as is someone whose build just broke.

**Two dead links fixed.** Both were repo-relative, which works on GitHub but resolves to nothing once synced onto the docs site — the same class as the adapter README links fixed in #1192:

- `docs/per-tenant-cube-sets.md` → the migration guide
- `CONTRIBUTING.md` → `CLAUDE.md#testing-in-a-constrained-environment`

Worth noting the help site's build does **not** validate links, so a green build is no evidence here; this class only surfaces by looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
