### PR TITLE
feat: collapse dashboard rows into sections under a markdown header

### DIFF
--- a/src/client/components/DashboardPortletCard.tsx
+++ b/src/client/components/DashboardPortletCard.tsx
@@ -51,7 +51,7 @@ const PortletChartBody = React.memo(function PortletChartBody({
   return (
     <div
       ref={setChartContainerRef}
-      className={`dc:flex-1 dc:min-h-0 dc:flex dc:flex-col${isTransparent ? '' : ' dc:px-2 dc:py-3 dc:md:px-4 dc:md:py-4'}`}
+      className={`dc-portlet-card-body dc:flex-1 dc:min-h-0 dc:flex dc:flex-col${isTransparent ? '' : ' dc:px-2 dc:py-3 dc:md:px-4 dc:md:py-4'}`}
     >
       <AnalyticsPortlet
         ref={setPortletComponentRef}
@@ -154,7 +154,7 @@ const DashboardPortletCard = React.memo(function DashboardPortletCard({
     variant
   })
 
-  const mergedHeaderClassName = buildHeaderClassName(isEditMode, headerProps?.className)
+  const mergedHeaderClassName = buildHeaderClassName(isEditMode, headerProps?.className, variant)
 
   const {
     onClick: containerOnClick,

--- a/src/client/components/MobileStackedLayout.tsx
+++ b/src/client/components/MobileStackedLayout.tsx
@@ -14,9 +14,19 @@ import { useTranslation } from '../hooks/useTranslation.js'
 import type { DashboardFilter, DashboardConfig, PortletConfig, PortletGroup } from '../types.js'
 import type { ColorPalette } from '../utils/colorPalettes.js'
 import { resolveMobilePortletDisplay } from './mobileStackedLayout/memberDisplay.js'
+import { headerHasBottomRule, isAutoHeightMarkdownPortlet } from './rowManagedLayout/sections.js'
 // Shared with DashboardCoordinator so both layouts detect the scroll container
 // the same way - this was previously duplicated here and drifted.
 import { findScrollableAncestor } from './dashboard/dashboardGridUtils.js'
+
+type Block =
+  | { kind: 'portlet'; sort: [number, number]; portlet: PortletConfig }
+  | { kind: 'group'; sort: [number, number]; group: PortletGroup; portlets: PortletConfig[] }
+
+/** Same banding as the desktop row layout - see `rowManagedLayout/sections.ts`. */
+type MobileBand =
+  | { kind: 'loose'; block: Block }
+  | { kind: 'section'; header: Block; body: Block[] }
 
 interface MobileStackedLayoutProps {
   config: DashboardConfig
@@ -56,10 +66,6 @@ export default function MobileStackedLayout({
     const byId = new Map(config.portlets.map(portlet => [portlet.id, portlet]))
     const grouped = new Set<string>()
 
-    type Block =
-      | { kind: 'portlet'; sort: [number, number]; portlet: PortletConfig }
-      | { kind: 'group'; sort: [number, number]; group: PortletGroup; portlets: PortletConfig[] }
-
     const result: Block[] = []
 
     for (const group of config.groups ?? []) {
@@ -85,6 +91,49 @@ export default function MobileStackedLayout({
     )
   }, [config.groups, config.portlets])
 
+  /**
+   * A section header is a lone full-width markdown block. Blocks are already
+   * grouped by grid row via `sort[0]`, so "sole block on its row" stands in for
+   * full width here: `portlet.w` is only re-derived from the rows on save, so it
+   * can be stale, while the y-grouping cannot.
+   *
+   * Banding is a rows-mode idea, but this component renders grid-mode
+   * dashboards too - hence the layoutMode gate.
+   */
+  const bands = useMemo<MobileBand[] | null>(() => {
+    if (config.layoutMode !== 'rows') return null
+
+    const blocksPerRow = new Map<number, number>()
+    blocks.forEach(block => {
+      blocksPerRow.set(block.sort[0], (blocksPerRow.get(block.sort[0]) ?? 0) + 1)
+    })
+    const isHeader = (block: Block) =>
+      block.kind === 'portlet' &&
+      blocksPerRow.get(block.sort[0]) === 1 &&
+      isAutoHeightMarkdownPortlet(block.portlet)
+
+    const result: MobileBand[] = []
+    let index = 0
+    while (index < blocks.length) {
+      if (!isHeader(blocks[index])) {
+        result.push({ kind: 'loose', block: blocks[index] })
+        index += 1
+        continue
+      }
+      const header = blocks[index]
+      const body: Block[] = []
+      index += 1
+      while (index < blocks.length && !isHeader(blocks[index])) {
+        body.push(blocks[index])
+        index += 1
+      }
+      // A header with nothing under it is a note, not an empty section card.
+      result.push(body.length === 0 ? { kind: 'loose', block: header } : { kind: 'section', header, body })
+    }
+
+    return result.some(band => band.kind === 'section') ? result : null
+  }, [blocks, config.layoutMode])
+
   const handlePortletRefresh = (portletId: string) => {
     // Refresh the specific portlet component
     portletComponentRefs.current[portletId]?.refresh()
@@ -97,10 +146,13 @@ export default function MobileStackedLayout({
    * since charts need one to render. `framed` is false inside a group, where
    * the group card supplies the border.
    */
-  const renderPortlet = (portlet: PortletConfig, framed: boolean, memberCount = 1) => {
+  const renderPortlet = (portlet: PortletConfig, framed: boolean, memberCount = 1, inSection = false) => {
     const display = resolveMobilePortletDisplay({ portlet, framed, memberCount })
     const { isTransparent, isAutoHeight, shouldHideHeader, contentHeight } = display
-    const bare = isTransparent || !framed
+    // A section child stays `framed` so it keeps its title - unlike a group
+    // child, the section card has no title of its own to carry it - but the
+    // section draws the frame, so the card itself is bare.
+    const bare = isTransparent || !framed || inSection
 
     return (
       <div
@@ -121,7 +173,11 @@ export default function MobileStackedLayout({
       >
         {/* Portlet Header - Simplified for mobile (no edit controls) */}
         {!shouldHideHeader && (
-          <div className="dc:flex dc:items-center dc:justify-between dc:px-3 dc:py-2 dc:border-b border-dc-border dc:shrink-0 bg-dc-surface-secondary dc:rounded-t-lg">
+          <div className={`dc:flex dc:items-center dc:justify-between dc:px-3 dc:shrink-0${
+            inSection
+              ? ' dc:py-3'
+              : ' dc:py-2 dc:border-b border-dc-border bg-dc-surface-secondary dc:rounded-t-lg'
+          }`}>
             <h3 className="dc:font-semibold dc:text-sm text-dc-text dc:truncate dc:flex-1">
               {portlet.title}
             </h3>
@@ -139,7 +195,7 @@ export default function MobileStackedLayout({
 
         {/* Portlet Content - explicit height for charts to render */}
         <div
-          className={`dc:overflow-visible dc:flex dc:flex-col${isTransparent ? '' : ' dc:px-2 dc:py-3'}`}
+          className={`dc-portlet-card-body dc:overflow-visible dc:flex dc:flex-col${isTransparent && !inSection ? '' : ' dc:px-2 dc:py-3'}`}
           style={{ height: isAutoHeight ? 'auto' : contentHeight }}
         >
           <AnalyticsPortlet
@@ -160,36 +216,60 @@ export default function MobileStackedLayout({
     )
   }
 
+  /** Identifies a band for React; groups and portlets share the key space. */
+  const blockKey = (block: Block) => block.kind === 'group' ? block.group.id : block.portlet.id
+
+  /** One block, framed on its own or bare inside a section card. */
+  const renderBlock = (block: Block, inSection: boolean) => {
+    if (block.kind === 'portlet') return renderPortlet(block.portlet, true, 1, inSection)
+
+    // A group keeps its single frame on mobile; its members stack
+    // vertically inside it whatever the group's desktop direction was.
+    return (
+      <div
+        key={block.group.id}
+        data-group-id={block.group.id}
+        className={`dc:flex dc:flex-col${inSection ? '' : ' bg-dc-surface dc:border border-dc-border dc:rounded-lg'}`}
+        style={{ boxShadow: inSection ? 'none' : 'var(--dc-shadow-sm)' }}
+      >
+        {block.group.title && block.group.title.trim() && (
+          <div className="dc:flex dc:items-center dc:px-3 dc:py-2 dc:border-b border-dc-border dc:shrink-0 bg-dc-surface-secondary dc:rounded-t-lg">
+            <h3 className="dc:font-semibold dc:text-sm text-dc-text dc:truncate">
+              {block.group.title}
+            </h3>
+          </div>
+        )}
+        <div className="dc:flex dc:flex-col dc:p-1 dc:gap-1">
+          {block.portlets.map(portlet =>
+            renderPortlet(portlet, false, block.portlets.length)
+          )}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <ScrollContainerProvider value={scrollContainer}>
       <div ref={setContainerRef} className="mobile-stacked-layout dc:space-y-4 dc:px-2">
-        {blocks.map(block => {
-          if (block.kind === 'portlet') return renderPortlet(block.portlet, true)
-
-          // A group keeps its single frame on mobile; its members stack
-          // vertically inside it whatever the group's desktop direction was.
-          return (
-            <div
-              key={block.group.id}
-              data-group-id={block.group.id}
-              className="bg-dc-surface dc:border border-dc-border dc:rounded-lg dc:flex dc:flex-col"
-              style={{ boxShadow: 'var(--dc-shadow-sm)' }}
-            >
-              {block.group.title && block.group.title.trim() && (
-                <div className="dc:flex dc:items-center dc:px-3 dc:py-2 dc:border-b border-dc-border dc:shrink-0 bg-dc-surface-secondary dc:rounded-t-lg">
-                  <h3 className="dc:font-semibold dc:text-sm text-dc-text dc:truncate">
-                    {block.group.title}
-                  </h3>
-                </div>
-              )}
-              <div className="dc:flex dc:flex-col dc:p-1 dc:gap-1">
-                {block.portlets.map(portlet =>
-                  renderPortlet(portlet, false, block.portlets.length)
-                )}
-              </div>
-            </div>
-          )
-        })}
+        {bands
+          ? bands.map(band => (
+              band.kind === 'loose'
+                ? renderBlock(band.block, false)
+                : (
+                  <div
+                    className={`dc-dashboard-section${
+                      band.header.kind === 'portlet' && headerHasBottomRule(band.header.portlet)
+                        ? ' dc-dashboard-section-ruled'
+                        : ''
+                    }`}
+                    key={`section-${blockKey(band.header)}`}
+                  >
+                    {renderBlock(band.header, true)}
+                    {band.body.map(block => renderBlock(block, true))}
+                  </div>
+                )
+            ))
+          : blocks.map(block => renderBlock(block, false))}
       </div>
     </ScrollContainerProvider>
   )

--- a/src/client/components/PortletGroupCard.tsx
+++ b/src/client/components/PortletGroupCard.tsx
@@ -55,6 +55,8 @@ export interface PortletGroupCardProps {
   onChildDragEnd: () => void
   /** Snap bands rendered inside each child; supplied by the row layout. */
   renderSnapBands?: (portletId: string) => ReactNode
+  /** Set inside a section card, which draws the only frame for the whole band. */
+  frameless?: boolean
 }
 
 export default function PortletGroupCard({
@@ -67,7 +69,8 @@ export default function PortletGroupCard({
   onDelete,
   onChildDragStart,
   onChildDragEnd,
-  renderSnapBands
+  renderSnapBands,
+  frameless = false
 }: PortletGroupCardProps) {
   const { t } = useTranslation()
   const [isEditingTitle, setIsEditingTitle] = useState(false)
@@ -142,8 +145,8 @@ export default function PortletGroupCard({
 
   return (
     <div
-      className="dc-portlet-group bg-dc-surface dc:border border-dc-border dc:rounded-lg dc:flex dc:flex-col dc:h-full dc:min-h-0 dc:relative"
-      style={{ boxShadow: 'var(--dc-shadow-sm)' }}
+      className={`dc-portlet-group${frameless ? ' dc-portlet-group-frameless' : ' bg-dc-surface dc:border border-dc-border dc:rounded-lg'} dc:flex dc:flex-col dc:h-full dc:min-h-0 dc:relative`}
+      style={{ boxShadow: frameless ? 'none' : 'var(--dc-shadow-sm)' }}
       data-group-id={group.id}
     >
       {(hasTitle || isEditingTitle) && (

--- a/src/client/components/RowManagedLayout.tsx
+++ b/src/client/components/RowManagedLayout.tsx
@@ -1,7 +1,8 @@
 import { Fragment, useState, useCallback, type HTMLAttributes, type ReactNode, type MouseEvent, type DragEvent } from 'react'
 import type { DashboardGridSettings, PortletConfig, PortletGroup, RowLayout } from '../types.js'
 import type { SnapEdge } from '../hooks/dashboard/groupUtils.js'
-import { ensureAnalysisConfig } from '../utils/configMigration.js'
+import type { PortletCardVariant } from './dashboardPortletCard/cardStyles.js'
+import { computeRowBands, headerHasBottomRule, isAutoHeightRow } from './rowManagedLayout/sections.js'
 
 const SNAP_EDGES: SnapEdge[] = ['top', 'right', 'bottom', 'left']
 
@@ -32,11 +33,18 @@ interface RowManagedLayoutProps {
   draggingPortletId?: string | null
   /** Id of the group currently being dragged, so its members ignore their bands. */
   draggingGroupId?: string | null
-  renderPortlet: (portlet: PortletConfig, containerProps?: HTMLAttributes<HTMLDivElement>, headerProps?: HTMLAttributes<HTMLDivElement>) => ReactNode
+  renderPortlet: (
+    portlet: PortletConfig,
+    containerProps?: HTMLAttributes<HTMLDivElement>,
+    headerProps?: HTMLAttributes<HTMLDivElement>,
+    variant?: PortletCardVariant
+  ) => ReactNode
   /** Renders a group column. Omitted in contexts that have no groups. */
   renderGroup?: (
     group: PortletGroup,
-    renderSnapBands: (portletId: string) => ReactNode
+    renderSnapBands: (portletId: string) => ReactNode,
+    /** Set inside a section, where the section card draws the only frame. */
+    frameless?: boolean
   ) => ReactNode
 }
 
@@ -128,6 +136,154 @@ export default function RowManagedLayout({
     })
   }, [activeDropKey, canEdit, draggingGroupId, draggingPortletId, isDragging, onSnapDrop])
 
+  const bands = canEdit ? null : computeRowBands(rows, portletMap, gridSettings.cols)
+
+  /** A header drawing its own bottom line supplies the divider the section would draw. */
+  const sectionHeaderIsRuled = (headerRowIndex: number): boolean => {
+    const portletId = rows[headerRowIndex]?.columns[0]?.portletId
+    const portlet = portletId ? portletMap.get(portletId) : undefined
+    return !!portlet && headerHasBottomRule(portlet)
+  }
+
+  /**
+   * One row. Split out of the render so a section band can call it for a run
+   * of rows, and so the banded and flat paths stay one definition.
+   */
+  const renderRow = (row: RowLayout, rowIndex: number, inSection: boolean): ReactNode => {
+    const autoHeight = isAutoHeightRow(row, portletMap)
+    const rowHeight = autoHeight ? undefined : row.h * gridSettings.rowHeight
+    const safeGridWidth = gridWidth || gridSettings.cols * gridSettings.rowHeight
+    const paddingLeft = activeDropKey === `row-${rowIndex}-insert-0` ? COLUMN_GAP : 0
+    const paddingRight = activeDropKey === `row-${rowIndex}-insert-${row.columns.length}` ? COLUMN_GAP : 0
+    const rowContentWidth = safeGridWidth - (row.columns.length - 1) * COLUMN_GAP - paddingLeft - paddingRight
+    const unitWidth = rowContentWidth / gridSettings.cols
+
+    return (
+      <div key={row.id} className="dc-row-layout-row-wrapper">
+        <div
+          className="dc-row-layout-row"
+          style={{
+            height: rowHeight ?? 'auto',
+            paddingLeft,
+            paddingRight,
+          }}
+        >
+          {row.columns.map((column, columnIndex) => {
+            const group = column.groupId ? groupMap.get(column.groupId) : undefined
+            const portlet =
+              !group && column.portletId ? portletMap.get(column.portletId) : undefined
+            if (!group && !portlet) return null
+
+            const key = group ? group.id : portlet!.id
+            const width = column.w * unitWidth
+
+            // Without this the only sign a drag is live is the native ghost:
+            // drop zones stay invisible until one is hovered.
+            const isBeingDragged = group
+              ? draggingGroupId === group.id
+              : draggingPortletId === portlet!.id
+
+            return (
+              <div
+                key={key}
+                className={`dc-row-layout-column-wrapper dc-row-layout-column${isBeingDragged ? ' dc-row-layout-column-dragging' : ''}`}
+                draggable={canEdit}
+                data-row-index={rowIndex.toString()}
+                data-column-index={columnIndex.toString()}
+                data-portlet-id={portlet?.id}
+                data-group-id={group?.id}
+                onDragStart={handlePortletDragStart}
+                onDragEnd={handlePortletDragEnd}
+                style={{
+                  flex: `0 0 ${width}px`,
+                  maxWidth: `${width}px`
+                }}
+              >
+                {group
+                  ? renderGroup?.(group, renderSnapBands, inSection)
+                  : (
+                    <>
+                      {renderPortlet(portlet!, undefined, undefined, inSection ? 'sectionChild' : 'standalone')}
+                      {renderSnapBands(portlet!.id)}
+                    </>
+                  )}
+                {columnIndex < row.columns.length - 1 && (
+                  <div
+                    className={`dc-column-resize-handle dc-split-handle${activeDropKey === `row-${rowIndex}-insert-${columnIndex + 1}` ? ' dc-drop-zone-active' : ''}`}
+                    onMouseDown={(event) => onColumnResize(rowIndex, columnIndex, event)}
+                    onDragOver={(event) => {
+                      if (!canEdit) return
+                      event.preventDefault()
+                      setDropActive(`row-${rowIndex}-insert-${columnIndex + 1}`)
+                    }}
+                    onDragLeave={() => setDropActive(null)}
+                    onDrop={(event) => {
+                      if (!canEdit) return
+                      event.preventDefault()
+                      event.stopPropagation()
+                      setDropActive(null)
+                      onRowDrop(rowIndex, columnIndex + 1)
+                    }}
+                  />
+                )}
+              </div>
+            )
+          })}
+        </div>
+        {canEdit && (
+          <>
+            <div
+              className={`dc-row-edge-drop dc-row-edge-drop-left dc-split-handle${activeDropKey === `row-${rowIndex}-insert-0` ? ' dc-drop-zone-active' : ''}`}
+              onDragOver={(event) => {
+                event.preventDefault()
+                setDropActive(`row-${rowIndex}-insert-0`)
+              }}
+              onDragLeave={() => {
+                setDropActive(null)
+              }}
+              onDrop={(event) => {
+                event.preventDefault()
+                setDropActive(null)
+                onRowDrop(rowIndex, 0)
+              }}
+            />
+            <div
+              className={`dc-row-edge-drop dc-row-edge-drop-right dc-split-handle${activeDropKey === `row-${rowIndex}-insert-${row.columns.length}` ? ' dc-drop-zone-active' : ''}`}
+              onDragOver={(event) => {
+                event.preventDefault()
+                setDropActive(`row-${rowIndex}-insert-${row.columns.length}`)
+              }}
+              onDragLeave={() => {
+                setDropActive(null)
+              }}
+              onDrop={(event) => {
+                event.preventDefault()
+                setDropActive(null)
+                onRowDrop(rowIndex, row.columns.length)
+              }}
+            />
+          </>
+        )}
+        {canEdit && (
+          <div
+            className={`dc-row-resize-handle dc-split-handle${autoHeight ? ' dc-row-resize-handle-drop-only' : ''}${activeDropKey === `row-insert-${rowIndex + 1}` ? ' dc-drop-zone-active' : ''}`}
+            onMouseDown={autoHeight ? undefined : (event) => onRowResize(rowIndex, event)}
+            onDragOver={(event) => {
+              event.preventDefault()
+              setDropActive(`row-insert-${rowIndex + 1}`)
+            }}
+            onDragLeave={() => setDropActive(null)}
+            onDrop={(event) => {
+              event.preventDefault()
+              setDropActive(null)
+              onNewRowDrop(rowIndex + 1)
+            }}
+          />
+        )}
+      </div>
+    )
+  }
+
   const topDropActive = activeDropKey === 'row-insert-0'
   const bottomDropActive = activeDropKey === 'row-bottom'
 
@@ -156,149 +312,21 @@ export default function RowManagedLayout({
           }}
         />
       )}
-      {rows.map((row, rowIndex) => {
-        // Row auto-height only when all columns are markdown and request autoHeight.
-        const isAutoHeightRow = row.columns.length > 0 && row.columns.every(col => {
-          // A group column has an explicit height, so it never auto-heights.
-          if (col.groupId) return false
-          const portlet = col.portletId ? portletMap.get(col.portletId) : undefined
-          if (!portlet) return false
-          const normalized = ensureAnalysisConfig(portlet)
-          const chartMode = normalized.analysisConfig.charts[normalized.analysisConfig.analysisType]
-          return chartMode?.chartType === 'markdown' && (chartMode.displayConfig?.autoHeight ?? true)
-        })
-        const rowHeight = isAutoHeightRow ? undefined : row.h * gridSettings.rowHeight
-        const safeGridWidth = gridWidth || gridSettings.cols * gridSettings.rowHeight
-        const paddingLeft = activeDropKey === `row-${rowIndex}-insert-0` ? COLUMN_GAP : 0
-        const paddingRight = activeDropKey === `row-${rowIndex}-insert-${row.columns.length}` ? COLUMN_GAP : 0
-        const rowContentWidth = safeGridWidth - (row.columns.length - 1) * COLUMN_GAP - paddingLeft - paddingRight
-        const unitWidth = rowContentWidth / gridSettings.cols
-
-        return (
-          <div key={row.id} className="dc-row-layout-row-wrapper">
-            <div
-              className="dc-row-layout-row"
-              style={{
-                height: rowHeight ?? 'auto',
-                paddingLeft,
-                paddingRight,
-              }}
-            >
-              {row.columns.map((column, columnIndex) => {
-                const group = column.groupId ? groupMap.get(column.groupId) : undefined
-                const portlet =
-                  !group && column.portletId ? portletMap.get(column.portletId) : undefined
-                if (!group && !portlet) return null
-
-                const key = group ? group.id : portlet!.id
-                const width = column.w * unitWidth
-
-                // Without this the only sign a drag is live is the native ghost:
-                // drop zones stay invisible until one is hovered.
-                const isBeingDragged = group
-                  ? draggingGroupId === group.id
-                  : draggingPortletId === portlet!.id
-
-                return (
-                  <div
-                    key={key}
-                    className={`dc-row-layout-column-wrapper dc-row-layout-column${isBeingDragged ? ' dc-row-layout-column-dragging' : ''}`}
-                    draggable={canEdit}
-                    data-row-index={rowIndex.toString()}
-                    data-column-index={columnIndex.toString()}
-                    data-portlet-id={portlet?.id}
-                    data-group-id={group?.id}
-                    onDragStart={handlePortletDragStart}
-                    onDragEnd={handlePortletDragEnd}
-                    style={{
-                      flex: `0 0 ${width}px`,
-                      maxWidth: `${width}px`
-                    }}
-                  >
-                    {group
-                      ? renderGroup?.(group, renderSnapBands)
-                      : (
-                        <>
-                          {renderPortlet(portlet!)}
-                          {renderSnapBands(portlet!.id)}
-                        </>
-                      )}
-                    {columnIndex < row.columns.length - 1 && (
-                      <div
-                        className={`dc-column-resize-handle dc-split-handle${activeDropKey === `row-${rowIndex}-insert-${columnIndex + 1}` ? ' dc-drop-zone-active' : ''}`}
-                        onMouseDown={(event) => onColumnResize(rowIndex, columnIndex, event)}
-                        onDragOver={(event) => {
-                          if (!canEdit) return
-                          event.preventDefault()
-                          setDropActive(`row-${rowIndex}-insert-${columnIndex + 1}`)
-                        }}
-                        onDragLeave={() => setDropActive(null)}
-                        onDrop={(event) => {
-                          if (!canEdit) return
-                          event.preventDefault()
-                          event.stopPropagation()
-                          setDropActive(null)
-                          onRowDrop(rowIndex, columnIndex + 1)
-                        }}
-                      />
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-            {canEdit && (
-              <>
+      {bands
+        ? bands.map(band => (
+            band.kind === 'loose'
+              ? renderRow(rows[band.rowIndex], band.rowIndex, false)
+              : (
                 <div
-                  className={`dc-row-edge-drop dc-row-edge-drop-left dc-split-handle${activeDropKey === `row-${rowIndex}-insert-0` ? ' dc-drop-zone-active' : ''}`}
-                  onDragOver={(event) => {
-                    event.preventDefault()
-                    setDropActive(`row-${rowIndex}-insert-0`)
-                  }}
-                  onDragLeave={() => {
-                    setDropActive(null)
-                  }}
-                  onDrop={(event) => {
-                    event.preventDefault()
-                    setDropActive(null)
-                    onRowDrop(rowIndex, 0)
-                  }}
-                />
-                <div
-                  className={`dc-row-edge-drop dc-row-edge-drop-right dc-split-handle${activeDropKey === `row-${rowIndex}-insert-${row.columns.length}` ? ' dc-drop-zone-active' : ''}`}
-                  onDragOver={(event) => {
-                    event.preventDefault()
-                    setDropActive(`row-${rowIndex}-insert-${row.columns.length}`)
-                  }}
-                  onDragLeave={() => {
-                    setDropActive(null)
-                  }}
-                  onDrop={(event) => {
-                    event.preventDefault()
-                    setDropActive(null)
-                    onRowDrop(rowIndex, row.columns.length)
-                  }}
-                />
-              </>
-            )}
-            {canEdit && (
-              <div
-                className={`dc-row-resize-handle dc-split-handle${isAutoHeightRow ? ' dc-row-resize-handle-drop-only' : ''}${activeDropKey === `row-insert-${rowIndex + 1}` ? ' dc-drop-zone-active' : ''}`}
-                onMouseDown={isAutoHeightRow ? undefined : (event) => onRowResize(rowIndex, event)}
-                onDragOver={(event) => {
-                  event.preventDefault()
-                  setDropActive(`row-insert-${rowIndex + 1}`)
-                }}
-                onDragLeave={() => setDropActive(null)}
-                onDrop={(event) => {
-                  event.preventDefault()
-                  setDropActive(null)
-                  onNewRowDrop(rowIndex + 1)
-                }}
-              />
-            )}
-          </div>
-        )
-      })}
+                  className={`dc-dashboard-section${sectionHeaderIsRuled(band.headerRowIndex) ? ' dc-dashboard-section-ruled' : ''}`}
+                  key={`section-${rows[band.headerRowIndex].id}`}
+                >
+                  {renderRow(rows[band.headerRowIndex], band.headerRowIndex, true)}
+                  {band.bodyRowIndices.map(index => renderRow(rows[index], index, true))}
+                </div>
+              )
+          ))
+        : rows.map((row, rowIndex) => renderRow(row, rowIndex, false))}
       {canEdit && (
         <div
           className={`dc-row-boundary-drop dc-row-boundary-drop-bottom dc-split-handle${activeDropKey === 'row-bottom' ? ' dc-drop-zone-active' : ''}`}

--- a/src/client/components/charts/MarkdownChart.tsx
+++ b/src/client/components/charts/MarkdownChart.tsx
@@ -130,7 +130,7 @@ const MarkdownChart = React.memo(function MarkdownChart({
 
   return (
     <div
-      className={`dc:w-full dc:overflow-auto ${transparentBackground ? '' : 'dc:p-4 '}${fontSizeClasses[fontSize] || 'dc:text-lg'} ${alignmentClasses[alignment] || 'dc:text-left'}`}
+      className={`dc-markdown-content dc:w-full dc:overflow-auto ${transparentBackground ? '' : 'dc:p-4 '}${fontSizeClasses[fontSize] || 'dc:text-lg'} ${alignmentClasses[alignment] || 'dc:text-left'}`}
       style={{
         height: height === "100%" ? "100%" : height,
         ...accentBorderStyle

--- a/src/client/components/dashboard/DashboardCoordinator.tsx
+++ b/src/client/components/dashboard/DashboardCoordinator.tsx
@@ -982,12 +982,14 @@ export default function DashboardCoordinator({
 
   const renderGroupCard = useCallback((
     group: PortletGroup,
-    renderSnapBands: (portletId: string) => ReactNode
+    renderSnapBands: (portletId: string) => ReactNode,
+    frameless?: boolean
   ): ReactNode => (
     <PortletGroupCard
       group={group}
       portlets={portletsById}
       canEdit={canEdit}
+      frameless={frameless}
       renderChild={(portlet, wrapperProps) => renderPortletCard(portlet, wrapperProps, undefined, 'groupChild')}
       onRename={(groupId, title) => { void actionsRef.current.renameGroup(groupId, title) }}
       onUngroup={(groupId) => { void actionsRef.current.ungroupGroup(groupId) }}

--- a/src/client/components/dashboardPortletCard/cardStyles.ts
+++ b/src/client/components/dashboardPortletCard/cardStyles.ts
@@ -6,8 +6,12 @@
 import type { CSSProperties } from 'react'
 import type { ChartType, ChartDisplayConfig } from '../../types.js'
 
-/** How much chrome a card draws. Group children are frameless and headerless. */
-export type PortletCardVariant = 'standalone' | 'groupChild'
+/**
+ * How much chrome a card draws. Group children are frameless and headerless;
+ * section children are frameless but otherwise behave like standalone cards,
+ * because the section card around them supplies the only frame.
+ */
+export type PortletCardVariant = 'standalone' | 'groupChild' | 'sectionChild'
 
 export interface PortletDisplayModes {
   isMarkdownAutoHeight: boolean
@@ -47,12 +51,26 @@ export function resolveDisplayModes(params: {
   // isTransparent gated on !isEditMode so chrome is visible for editing
   const markdownAutoHeightRequested = isMarkdown && (renderDisplayConfig?.autoHeight ?? true)
   const isMarkdownAutoHeight = layoutMode !== 'grid' && markdownAutoHeightRequested
-  const isTransparentContent = isMarkdown && !!renderDisplayConfig?.transparentBackground
-  const isTransparent = isTransparentContent && !isEditMode
   // Hide header when: explicitly set to hide, OR markdown with no title
   const shouldHideHeader = isMarkdown
     ? (renderDisplayConfig?.hideHeader ?? true) || !!renderDisplayConfig?.transparentBackground || !portletTitle
     : (renderDisplayConfig?.hideHeader ?? false)
+
+  // Inside a section the two transparency flags come apart. The frame always
+  // goes - the section card draws it once for the whole band - but the content
+  // padding stays, or a `transparentBackground` header (which drops both its
+  // own padding and the card's) would sit flush against the section's edge.
+  if (variant === 'sectionChild') {
+    return {
+      isMarkdownAutoHeight,
+      isTransparentContent: false,
+      isTransparent: true,
+      shouldHideHeader
+    }
+  }
+
+  const isTransparentContent = isMarkdown && !!renderDisplayConfig?.transparentBackground
+  const isTransparent = isTransparentContent && !isEditMode
 
   return { isMarkdownAutoHeight, isTransparentContent, isTransparent, shouldHideHeader }
 }
@@ -79,6 +97,9 @@ export function buildContainerClassName(params: {
   }
 
   return [
+    // A section child is frameless for the same reason a group child is: the
+    // card around it owns the border, background and shadow.
+    variant === 'sectionChild' ? 'dc-portlet-section-child' : '',
     isTransparent
       ? 'dc:flex dc:flex-col dc:transition-all'
       : 'bg-dc-surface dc:border dc:rounded-lg dc:flex dc:flex-col dc:transition-all',
@@ -90,9 +111,24 @@ export function buildContainerClassName(params: {
     .join(' ')
 }
 
-export function buildHeaderClassName(isEditMode: boolean, extraClassName?: string): string {
+export function buildHeaderClassName(
+  isEditMode: boolean,
+  extraClassName?: string,
+  variant?: PortletCardVariant
+): string {
+  // Inside a section the header sits mid-card, so a standalone card's grey fill,
+  // rounded top corners and underline all read as clutter. The section draws one
+  // set of rules *between* portlets instead, so the title needs none of its own.
+  const inSection = variant === 'sectionChild'
+
   return [
-    'dc:flex dc:items-center dc:justify-between dc:px-3 dc:py-1.5 dc:md:px-4 dc:md:py-1 dc:border-b border-dc-border dc:shrink-0 bg-dc-surface-secondary dc:rounded-t-lg portlet-drag-handle',
+    'dc:flex dc:items-center dc:justify-between dc:px-3 dc:md:px-4 dc:shrink-0 portlet-drag-handle',
+    // A standalone card's header is a tight bar against its own top edge. In a
+    // section the title sits just under a divider with nothing else marking the
+    // boundary, so it needs room to breathe.
+    inSection
+      ? 'dc:py-3 dc:md:py-3'
+      : 'dc:py-1.5 dc:md:py-1 dc:border-b border-dc-border bg-dc-surface-secondary dc:rounded-t-lg',
     isEditMode ? 'dc:cursor-move' : 'dc:cursor-default',
     extraClassName
   ]
@@ -112,6 +148,18 @@ export function buildContainerStyle(params: {
 
   if (variant === 'groupChild') {
     // Borderless, so filter selection is signalled with an inset ring instead.
+    return {
+      boxShadow: selected ? 'inset 0 0 0 2px var(--dc-primary)' : 'none',
+      borderWidth: 0,
+      backgroundColor: selected ? 'color-mix(in srgb, var(--dc-primary) 5%, transparent)' : 'transparent',
+      opacity: isInSelectionMode && !hasSelectedFilter ? '0.5' : '1',
+      ...containerStyle
+    }
+  }
+
+  if (variant === 'sectionChild') {
+    // Borderless like a group child, so filter selection is signalled with an
+    // inset ring rather than by recolouring a border that isn't drawn.
     return {
       boxShadow: selected ? 'inset 0 0 0 2px var(--dc-primary)' : 'none',
       borderWidth: 0,

--- a/src/client/components/rowManagedLayout/sections.ts
+++ b/src/client/components/rowManagedLayout/sections.ts
@@ -1,0 +1,128 @@
+/**
+ * Groups a row layout into "sections": a full-width markdown header row plus
+ * every row beneath it, up to the next header. The row layout itself stays a
+ * flat ordered list - this is a read-only view over it, used to draw a section
+ * as one card instead of a pile of separate ones.
+ *
+ * Pure and DOM-free on purpose: nothing here measures rendered content, so the
+ * same answer holds on the server, in tests and mid-drag.
+ */
+
+import type { PortletConfig, RowLayout } from '../../types.js'
+import { ensureAnalysisConfig } from '../../utils/configMigration.js'
+
+/** A markdown portlet that sizes itself to its content - the shape of a header. */
+export function isAutoHeightMarkdownPortlet(portlet: PortletConfig): boolean {
+  const normalized = ensureAnalysisConfig(portlet)
+  const chartMode = normalized.analysisConfig.charts[normalized.analysisConfig.analysisType]
+  return chartMode?.chartType === 'markdown' && (chartMode.displayConfig?.autoHeight ?? true)
+}
+
+/**
+ * A row sizes itself to its content only when every column is a markdown
+ * portlet asking for it. A group column has an explicit height, so it never
+ * auto-heights.
+ */
+export function isAutoHeightRow(
+  row: RowLayout,
+  portletMap: Map<string, PortletConfig>
+): boolean {
+  return row.columns.length > 0 && row.columns.every(column => {
+    if (column.groupId) return false
+    const portlet = column.portletId ? portletMap.get(column.portletId) : undefined
+    return !!portlet && isAutoHeightMarkdownPortlet(portlet)
+  })
+}
+
+/**
+ * A section header is a lone full-width auto-height markdown row.
+ *
+ * The width test matters: a single column is not automatically full width, and
+ * one narrower than `cols` renders as a partial-width card that shouldn't
+ * capture the rows below it. `normalizeRows` -> `adjustRowWidths` guarantees a
+ * row's columns sum to exactly `cols`, so a lone column does reach it.
+ */
+export function isSectionHeaderRow(
+  row: RowLayout,
+  portletMap: Map<string, PortletConfig>,
+  cols: number
+): boolean {
+  if (row.columns.length !== 1) return false
+  const [column] = row.columns
+  if (column.groupId || !column.portletId) return false
+  if (Math.abs(column.w - cols) > 1e-6) return false
+  return isAutoHeightRow(row, portletMap)
+}
+
+/** A markdown rule: three or more of the same -, * or _, spaces allowed. */
+const MARKDOWN_RULE = /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/
+
+/**
+ * True when the header already draws its own line along its bottom edge -
+ * either the `accentBorder: 'bottom'` display option, or markdown content
+ * ending in a horizontal rule.
+ *
+ * Such a header separates itself from the section body, so the section must not
+ * draw its own divider underneath as well: two parallel lines a few pixels
+ * apart is the thing this whole feature exists to avoid.
+ */
+export function headerHasBottomRule(portlet: PortletConfig): boolean {
+  const normalized = ensureAnalysisConfig(portlet)
+  const chartMode = normalized.analysisConfig.charts[normalized.analysisConfig.analysisType]
+  const displayConfig = chartMode?.displayConfig
+  if (displayConfig?.accentBorder === 'bottom') return true
+
+  const content = displayConfig?.content
+  if (typeof content !== 'string') return false
+
+  const lines = content.trimEnd().split('\n')
+  return MARKDOWN_RULE.test(lines[lines.length - 1] ?? '')
+}
+
+export type RowBand =
+  /** A row that belongs to no section, drawn exactly as it always has been. */
+  | { kind: 'loose'; rowIndex: number }
+  | { kind: 'section'; headerRowIndex: number; bodyRowIndices: number[] }
+
+/**
+ * Split `rows` into bands top-down. Rows before the first header stay loose,
+ * and a header with nothing beneath it stays loose too - a trailing markdown
+ * note is a note, not an empty section card.
+ */
+export function computeRowBands(
+  rows: RowLayout[],
+  portletMap: Map<string, PortletConfig>,
+  cols: number
+): RowBand[] {
+  const bands: RowBand[] = []
+  let index = 0
+
+  while (index < rows.length) {
+    if (!isSectionHeaderRow(rows[index], portletMap, cols)) {
+      bands.push({ kind: 'loose', rowIndex: index })
+      index += 1
+      continue
+    }
+
+    const headerRowIndex = index
+    const bodyRowIndices: number[] = []
+    index += 1
+    while (index < rows.length && !isSectionHeaderRow(rows[index], portletMap, cols)) {
+      bodyRowIndices.push(index)
+      index += 1
+    }
+
+    bands.push(
+      bodyRowIndices.length === 0
+        ? { kind: 'loose', rowIndex: headerRowIndex }
+        : { kind: 'section', headerRowIndex, bodyRowIndices }
+    )
+  }
+
+  return bands
+}
+
+/** True when at least one section would be drawn - lets callers skip the wrapper entirely. */
+export function hasSection(bands: RowBand[]): boolean {
+  return bands.some(band => band.kind === 'section')
+}

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -55,6 +55,137 @@
   padding-bottom: var(--dc-row-gap, 24px);
 }
 
+/* A section: a full-width markdown header row plus the rows it introduces,
+   drawn as one card so the header visibly owns the block beneath it. Applied
+   in view mode only - in edit mode the row-resize handle and the boundary drop
+   zones live inside the very gap this collapses. */
+.dc-dashboard-section {
+  background-color: var(--dc-surface);
+  border: 1px solid var(--dc-border);
+  border-radius: var(--dc-radius-lg);
+  box-shadow: var(--dc-shadow-sm);
+  overflow: hidden;
+  margin-bottom: var(--dc-section-gap, 32px);
+}
+
+.dc-dashboard-section:last-child {
+  margin-bottom: 0;
+}
+
+/* Rows inside a section butt up against each other; the hairline does the
+   separating that the 24px gap used to. */
+/* Every row carries the same inset - the header included, or its text sits a
+   card's-worth of padding further left than the portlet titles below it. The
+   dividers stay full-bleed, since padding sits inside the border. */
+.dc-dashboard-section .dc-row-layout-row-wrapper {
+  padding-bottom: 0;
+  padding-left: var(--dc-section-inset, 16px);
+  padding-right: var(--dc-section-inset, 16px);
+}
+
+/* Drawn as an inset pseudo-element rather than a border on the wrapper: a
+   border runs the section's full width and butts into its left and right edges,
+   which reads as a different kind of line from the vertical rules floating in
+   the column gaps. Inset to the same margin, the two meet as one grid. */
+.dc-dashboard-section .dc-row-layout-row-wrapper + .dc-row-layout-row-wrapper::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: var(--dc-section-inset, 16px);
+  right: var(--dc-section-inset, 16px);
+  height: 1px;
+  background-color: var(--dc-border);
+  pointer-events: none;
+}
+
+/* A group inside a section is a band, not a nested box: drop the title bar's
+   fill, rounding and underline for the same reason the portlet headers lose
+   theirs. */
+.dc-dashboard-section .dc-portlet-group-frameless > .dc-portlet-group-title {
+  background-color: transparent;
+  border-bottom: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+/* Rules run *between* portlets, never under their titles. Drawn as a
+   pseudo-element centred in the gap rather than a border on the column, which
+   would hug the right-hand card and read as belonging to it. The column wrapper
+   is already `position: relative`, and the line sits inside the row's box, so
+   the row's `overflow: hidden` does not clip it. */
+.dc-dashboard-section .dc-row-layout-column-wrapper + .dc-row-layout-column-wrapper::before,
+.dc-dashboard-section .dc-portlet-group-cell + .dc-portlet-group-cell::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background-color: var(--dc-border);
+  pointer-events: none;
+}
+
+.dc-dashboard-section .dc-row-layout-column-wrapper + .dc-row-layout-column-wrapper::before {
+  left: calc(-1 * var(--dc-column-gap, 16px) / 2);
+}
+
+/* The header draws its own bottom line, so the section skips the divider it
+   would otherwise draw beneath it. */
+.dc-dashboard-section-ruled > *:nth-child(2)::after {
+  display: none;
+}
+
+/* Pin the section child's body padding to one value at every breakpoint. The
+   Tailwind default is responsive (px-2 -> md:px-4), which would leave the
+   full-bleed offset below unknowable. */
+.dc-dashboard-section .dc-portlet-card-body {
+  padding-left: var(--dc-section-card-inset, 16px);
+  padding-right: var(--dc-section-card-inset, 16px);
+}
+
+/* That bottom line stands in for the section's divider, so it has to reach the
+   section's edges. Widen the header's content box by exactly the padding
+   between it and them, then give the padding straight back - the border moves
+   out, the text does not. */
+.dc-dashboard-section-ruled > *:first-child .dc-markdown-content {
+  --dc-section-bleed: calc(var(--dc-section-inset, 16px) + var(--dc-section-card-inset, 16px));
+  /* The chart sets `width: 100%`, which pins the box to its container and lets
+     the negative margins shift it left without widening it - flush on one edge,
+     short on the other. `auto` lets both margins do their job. */
+  width: auto;
+  margin-left: calc(-1 * var(--dc-section-bleed));
+  margin-right: calc(-1 * var(--dc-section-bleed));
+  padding-left: var(--dc-section-bleed);
+  padding-right: var(--dc-section-bleed);
+}
+
+/* Rows clip their content, which would trim the bleed back off again. */
+.dc-dashboard-section-ruled > .dc-row-layout-row-wrapper:first-child .dc-row-layout-row {
+  overflow: visible;
+}
+
+.dc-dashboard-section .dc-portlet-group-cell + .dc-portlet-group-cell::before {
+  left: calc(-1 * var(--dc-group-gap, 4px) / 2);
+}
+
+/* The mobile stack has no row wrappers - its section children are the blocks
+   themselves - but they take the same inset and the same inset divider. */
+.mobile-stacked-layout .dc-dashboard-section > * {
+  position: relative;
+  padding-left: var(--dc-section-inset, 16px);
+  padding-right: var(--dc-section-inset, 16px);
+}
+
+.mobile-stacked-layout .dc-dashboard-section > * + *::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: var(--dc-section-inset, 16px);
+  right: var(--dc-section-inset, 16px);
+  height: 1px;
+  background-color: var(--dc-border);
+  pointer-events: none;
+}
+
 .dc-row-layout-row {
   display: flex;
   width: 100%;

--- a/tests/client/components/dashboardPortletCard/cardStyles.test.ts
+++ b/tests/client/components/dashboardPortletCard/cardStyles.test.ts
@@ -290,3 +290,78 @@ describe('buildHeaderClassName', () => {
     expect(buildHeaderClassName(false, 'extra')).toContain('extra')
   })
 })
+
+describe('sectionChild variant', () => {
+  it('drops the frame but keeps the content padding', () => {
+    // The section card draws the only frame; keeping isTransparentContent false
+    // is what stops a transparent markdown header sitting flush to its edge.
+    const modes = resolveDisplayModes({
+      renderChartType: 'markdown',
+      renderDisplayConfig: { transparentBackground: true },
+      layoutMode: 'rows',
+      isEditMode: false,
+      variant: 'sectionChild'
+    })
+
+    expect(modes.isTransparent).toBe(true)
+    expect(modes.isTransparentContent).toBe(false)
+  })
+
+  it('still auto-heights markdown outside grid mode', () => {
+    const modes = resolveDisplayModes({
+      renderChartType: 'markdown',
+      layoutMode: 'rows',
+      isEditMode: false,
+      variant: 'sectionChild'
+    })
+
+    expect(modes.isMarkdownAutoHeight).toBe(true)
+  })
+
+  it('is marked in the container class name', () => {
+    const className = buildContainerClassName({
+      isTransparent: true,
+      isMarkdownAutoHeight: false,
+      isInSelectionMode: false,
+      variant: 'sectionChild'
+    })
+
+    expect(className).toContain('dc-portlet-section-child')
+    expect(className).not.toContain('dc:border')
+  })
+
+  it('drops border, background and shadow from the container style', () => {
+    const style = buildContainerStyle({
+      isTransparent: true,
+      isInSelectionMode: false,
+      hasSelectedFilter: false,
+      variant: 'sectionChild'
+    })
+
+    expect(style.borderWidth).toBe(0)
+    expect(style.boxShadow).toBe('none')
+    expect(style.backgroundColor).toBe('transparent')
+  })
+
+  it('signals filter selection with an inset ring, having no border to recolour', () => {
+    const style = buildContainerStyle({
+      isTransparent: true,
+      isInSelectionMode: true,
+      hasSelectedFilter: true,
+      variant: 'sectionChild'
+    })
+
+    expect(style.boxShadow).toBe('inset 0 0 0 2px var(--dc-primary)')
+  })
+
+  it('drops the header fill, rounding and underline', () => {
+    const inSection = buildHeaderClassName(false, undefined, 'sectionChild')
+    const standalone = buildHeaderClassName(false, undefined, 'standalone')
+
+    expect(inSection).not.toContain('bg-dc-surface-secondary')
+    expect(inSection).not.toContain('dc:rounded-t-lg')
+    expect(inSection).not.toContain('dc:border-b')
+    expect(standalone).toContain('bg-dc-surface-secondary')
+    expect(standalone).toContain('dc:border-b')
+  })
+})

--- a/tests/client/components/layout/MobileStackedLayout.test.tsx
+++ b/tests/client/components/layout/MobileStackedLayout.test.tsx
@@ -654,4 +654,56 @@ describe('MobileStackedLayout', () => {
       expect(container.querySelector('[data-portlet-id="solo"]')).toBeInTheDocument()
     })
   })
+
+  describe('section banding', () => {
+    const header = createTestPortlet({
+      id: 'header-1',
+      title: 'Header',
+      chartType: 'markdown',
+      displayConfig: { autoHeight: true, content: '# Header' },
+      y: 0, x: 0, w: 12
+    })
+    const body = createTestPortlet({ id: 'p1', title: 'Body', y: 4, x: 0, w: 12 })
+
+    it('bands a header and the portlets beneath it in rows mode', () => {
+      const { container } = render(
+        <MobileStackedLayout config={{ portlets: [header, body], layoutMode: 'rows' }} />
+      )
+
+      const sections = container.querySelectorAll('.dc-dashboard-section')
+      expect(sections).toHaveLength(1)
+      expect(sections[0].children).toHaveLength(2)
+    })
+
+    it('does not band in grid mode, which has no row concept', () => {
+      const { container } = render(
+        <MobileStackedLayout config={{ portlets: [header, body], layoutMode: 'grid' }} />
+      )
+
+      expect(container.querySelector('.dc-dashboard-section')).toBeNull()
+    })
+
+    it('does not band a header that shares its row with another portlet', () => {
+      const sibling = createTestPortlet({ id: 'p2', y: 0, x: 6, w: 6 })
+      const { container } = render(
+        <MobileStackedLayout
+          config={{ portlets: [header, sibling, body], layoutMode: 'rows' }}
+        />
+      )
+
+      expect(container.querySelector('.dc-dashboard-section')).toBeNull()
+    })
+
+    it('marks the section ruled when the header draws its own bottom border', () => {
+      const ruled = {
+        ...header,
+        displayConfig: { autoHeight: true, content: '# Header', accentBorder: 'bottom' as const }
+      }
+      const { container } = render(
+        <MobileStackedLayout config={{ portlets: [ruled, body], layoutMode: 'rows' }} />
+      )
+
+      expect(container.querySelector('.dc-dashboard-section-ruled')).not.toBeNull()
+    })
+  })
 })

--- a/tests/client/components/layout/RowManagedLayout.test.tsx
+++ b/tests/client/components/layout/RowManagedLayout.test.tsx
@@ -1428,4 +1428,110 @@ describe('RowManagedLayout - groups and snap bands', () => {
       expect(active.classList.contains('dc-drop-zone-active')).toBe(true)
     })
   })
+
+  describe('section banding', () => {
+    const headerPortlet = (overrides = {}) =>
+      createMarkdownPortlet({ id: 'header-1', ...overrides })
+
+    const sectionRows = (): RowLayout[] => [
+      createTestRow({ id: 'row-header', h: 3, columns: [{ portletId: 'header-1', w: 12 }] }),
+      createTestRow({ id: 'row-body', h: 4, columns: [{ portletId: 'p1', w: 12 }] })
+    ]
+
+    const bodyPortlet = createTestPortlet({ id: 'p1' })
+
+    it('wraps a header and the rows beneath it in one section in view mode', () => {
+      const { container } = render(
+        <RowManagedLayout
+          {...defaultProps}
+          canEdit={false}
+          rows={sectionRows()}
+          portlets={[headerPortlet(), bodyPortlet]}
+        />
+      )
+
+      const sections = container.querySelectorAll('.dc-dashboard-section')
+      expect(sections).toHaveLength(1)
+      expect(sections[0].querySelectorAll('.dc-row-layout-row-wrapper')).toHaveLength(2)
+    })
+
+    it('renders no section in edit mode, so the drop and resize handles keep their gap', () => {
+      const { container } = render(
+        <RowManagedLayout
+          {...defaultProps}
+          canEdit
+          rows={sectionRows()}
+          portlets={[headerPortlet(), bodyPortlet]}
+        />
+      )
+
+      expect(container.querySelector('.dc-dashboard-section')).toBeNull()
+      expect(container.querySelectorAll('.dc-row-layout-row-wrapper')).toHaveLength(2)
+    })
+
+    it('renders the portlets inside a section with the sectionChild variant', () => {
+      const renderPortlet = vi.fn((portlet: PortletConfig) => (
+        <div data-testid={`portlet-${portlet.id}`}>{portlet.title}</div>
+      ))
+
+      render(
+        <RowManagedLayout
+          {...defaultProps}
+          canEdit={false}
+          rows={sectionRows()}
+          portlets={[headerPortlet(), bodyPortlet]}
+          renderPortlet={renderPortlet}
+        />
+      )
+
+      expect(renderPortlet).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'p1' }), undefined, undefined, 'sectionChild'
+      )
+    })
+
+    it('marks the section as ruled when the header draws its own bottom border', () => {
+      const { container } = render(
+        <RowManagedLayout
+          {...defaultProps}
+          canEdit={false}
+          rows={sectionRows()}
+          portlets={[
+            headerPortlet({ displayConfig: { autoHeight: true, accentBorder: 'bottom' } }),
+            bodyPortlet
+          ]}
+        />
+      )
+
+      expect(container.querySelector('.dc-dashboard-section-ruled')).not.toBeNull()
+    })
+
+    it('leaves a header with no rows beneath it loose', () => {
+      const { container } = render(
+        <RowManagedLayout
+          {...defaultProps}
+          canEdit={false}
+          rows={[createTestRow({ id: 'row-header', h: 3, columns: [{ portletId: 'header-1', w: 12 }] })]}
+          portlets={[headerPortlet()]}
+        />
+      )
+
+      expect(container.querySelector('.dc-dashboard-section')).toBeNull()
+    })
+
+    it('does not band a half-width markdown row', () => {
+      const { container } = render(
+        <RowManagedLayout
+          {...defaultProps}
+          canEdit={false}
+          rows={[
+            createTestRow({ id: 'r1', h: 3, columns: [{ portletId: 'header-1', w: 6 }, { portletId: 'p2', w: 6 }] }),
+            createTestRow({ id: 'r2', h: 4, columns: [{ portletId: 'p1', w: 12 }] })
+          ]}
+          portlets={[headerPortlet(), createMarkdownPortlet({ id: 'p2' }), bodyPortlet]}
+        />
+      )
+
+      expect(container.querySelector('.dc-dashboard-section')).toBeNull()
+    })
+  })
 })

--- a/tests/client/components/rowManagedLayout/sections.test.ts
+++ b/tests/client/components/rowManagedLayout/sections.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for section banding: which rows form a section under a markdown header.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  computeRowBands,
+  isSectionHeaderRow,
+  isAutoHeightMarkdownPortlet,
+  headerHasBottomRule
+} from '../../../../src/client/components/rowManagedLayout/sections'
+import type { PortletConfig, RowLayout } from '../../../../src/client/types'
+
+let seq = 0
+function portlet(overrides: Partial<PortletConfig> = {}): PortletConfig {
+  return {
+    id: `portlet-${seq++}`,
+    title: 'Test Portlet',
+    query: JSON.stringify({ measures: ['Test.count'] }),
+    chartType: 'bar',
+    x: 0, y: 0, w: 12, h: 4,
+    ...overrides
+  }
+}
+
+const markdown = (overrides: Partial<PortletConfig> = {}) =>
+  portlet({ chartType: 'markdown', displayConfig: { autoHeight: true }, ...overrides })
+
+function row(columns: RowLayout['columns']): RowLayout {
+  return { id: `row-${seq++}`, h: 4, columns }
+}
+
+const full = (p: PortletConfig) => row([{ portletId: p.id, w: 12 }])
+const half = (a: PortletConfig, b: PortletConfig) =>
+  row([{ portletId: a.id, w: 6 }, { portletId: b.id, w: 6 }])
+
+const mapOf = (...ps: PortletConfig[]) => new Map(ps.map(p => [p.id, p]))
+
+describe('isAutoHeightMarkdownPortlet', () => {
+  it('is true for markdown defaulting to autoHeight', () => {
+    expect(isAutoHeightMarkdownPortlet(portlet({ chartType: 'markdown' }))).toBe(true)
+  })
+
+  it('is false when autoHeight is explicitly off', () => {
+    expect(isAutoHeightMarkdownPortlet(markdown({ displayConfig: { autoHeight: false } }))).toBe(false)
+  })
+
+  it('is false for a chart', () => {
+    expect(isAutoHeightMarkdownPortlet(portlet())).toBe(false)
+  })
+})
+
+describe('isSectionHeaderRow', () => {
+  it('accepts a lone full-width auto-height markdown row', () => {
+    const header = markdown()
+    expect(isSectionHeaderRow(full(header), mapOf(header), 12)).toBe(true)
+  })
+
+  it('rejects a markdown row narrower than the grid', () => {
+    const header = markdown()
+    const other = markdown()
+    expect(isSectionHeaderRow(half(header, other), mapOf(header, other), 12)).toBe(false)
+  })
+
+  it('rejects a group column', () => {
+    expect(isSectionHeaderRow(row([{ groupId: 'group-1', w: 12 }]), new Map(), 12)).toBe(false)
+  })
+
+  it('rejects a chart portlet', () => {
+    const chart = portlet()
+    expect(isSectionHeaderRow(full(chart), mapOf(chart), 12)).toBe(false)
+  })
+
+  it('rejects markdown with autoHeight off', () => {
+    const fixed = markdown({ displayConfig: { autoHeight: false } })
+    expect(isSectionHeaderRow(full(fixed), mapOf(fixed), 12)).toBe(false)
+  })
+})
+
+describe('computeRowBands', () => {
+  it('leaves rows before the first header loose', () => {
+    const chart = portlet()
+    const header = markdown()
+    const body = portlet()
+    const rows = [full(chart), full(header), full(body)]
+    const bands = computeRowBands(rows, mapOf(chart, header, body), 12)
+
+    expect(bands).toEqual([
+      { kind: 'loose', rowIndex: 0 },
+      { kind: 'section', headerRowIndex: 1, bodyRowIndices: [2] }
+    ])
+  })
+
+  it('absorbs every row up to the next header', () => {
+    const h1 = markdown(), a = portlet(), b = portlet()
+    const h2 = markdown(), c = portlet()
+    const rows = [full(h1), full(a), full(b), full(h2), full(c)]
+    const bands = computeRowBands(rows, mapOf(h1, a, b, h2, c), 12)
+
+    expect(bands).toEqual([
+      { kind: 'section', headerRowIndex: 0, bodyRowIndices: [1, 2] },
+      { kind: 'section', headerRowIndex: 3, bodyRowIndices: [4] }
+    ])
+  })
+
+  it('leaves a header with no body row loose, so a trailing note is unchanged', () => {
+    const header = markdown(), chart = portlet()
+    const rows = [full(chart), full(header)]
+    const bands = computeRowBands(rows, mapOf(chart, header), 12)
+
+    expect(bands).toEqual([
+      { kind: 'loose', rowIndex: 0 },
+      { kind: 'loose', rowIndex: 1 }
+    ])
+  })
+
+  it('leaves back-to-back headers loose until one has content', () => {
+    const h1 = markdown(), h2 = markdown(), body = portlet()
+    const rows = [full(h1), full(h2), full(body)]
+    const bands = computeRowBands(rows, mapOf(h1, h2, body), 12)
+
+    expect(bands).toEqual([
+      { kind: 'loose', rowIndex: 0 },
+      { kind: 'section', headerRowIndex: 1, bodyRowIndices: [2] }
+    ])
+  })
+
+  it('returns all-loose bands for a dashboard with no markdown at all', () => {
+    const a = portlet(), b = portlet()
+    const bands = computeRowBands([full(a), full(b)], mapOf(a, b), 12)
+    expect(bands).toEqual([
+      { kind: 'loose', rowIndex: 0 },
+      { kind: 'loose', rowIndex: 1 }
+    ])
+  })
+})
+
+describe('headerHasBottomRule', () => {
+  it('detects the accentBorder bottom display option', () => {
+    expect(headerHasBottomRule(portlet({
+      chartType: 'markdown',
+      displayConfig: { autoHeight: true, accentBorder: 'bottom' }
+    }))).toBe(true)
+  })
+
+  it.each(['none', 'left', 'top'] as const)('ignores accentBorder %s', (accentBorder) => {
+    expect(headerHasBottomRule(portlet({
+      chartType: 'markdown',
+      displayConfig: { autoHeight: true, accentBorder }
+    }))).toBe(false)
+  })
+
+  const withContent = (content: string) =>
+    portlet({
+      chartType: 'markdown',
+      displayConfig: { autoHeight: true, content }
+    })
+
+  it.each([
+    ['dashes', '# Title\n\nSome text\n\n---'],
+    ['asterisks', '# Title\n***'],
+    ['underscores', '# Title\n___'],
+    ['spaced dashes', '# Title\n- - -'],
+    ['trailing newlines', '# Title\n\n---\n\n']
+  ])('detects a trailing rule (%s)', (_label, content) => {
+    expect(headerHasBottomRule(withContent(content))).toBe(true)
+  })
+
+  it.each([
+    ['no rule', '# Title\n\nSome text'],
+    ['rule not last', '# Title\n\n---\n\nMore text'],
+    ['too few dashes', '# Title\n--'],
+    ['a list item', '# Title\n- one'],
+    ['empty', '']
+  ])('returns false when there is no trailing rule (%s)', (_label, content) => {
+    expect(headerHasBottomRule(withContent(content))).toBe(false)
+  })
+
+  it('returns false when there is no content at all', () => {
+    expect(headerHasBottomRule(markdown())).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

A full-width markdown header row and the rows beneath it now render as **one card** — hairline rules between portlets, and a gap only before the next header.

Before, every row carried the same 24px gap (`.dc-row-layout-row-wrapper { padding-bottom: var(--dc-row-gap) }`), so a header sat as far from the content it introduced as that content sat from the next header. Nothing visually bound a section together, and dashboards read as a loose pile of disconnected cards.

## Scope

- **Rows layout mode only.** Grid mode has no row concept.
- **View mode only.** The row-resize handle and the boundary drop zones are positioned *inside* the gap a section collapses (`styles.css`), so edit mode renders exactly as before — the flat path is unchanged.
- Mobile stacked view gets the same banding, gated on `layoutMode === 'rows'` since that component serves both modes.

## Detection

Implicit — no config change, no migration, works on existing dashboards. A **lone full-width auto-height markdown row** is a header. Two rules keep the blast radius small:

- a header forms a section only when at least one row follows it, so a trailing markdown note stays loose;
- rows before the first header stay loose.

The full-width test is meaningful: `normalizeRows` → `adjustRowWidths` guarantees a row's columns sum to `cols`, so a lone column always reaches it, while a narrower one correctly does not capture the rows below.

Escape hatch: set the markdown's `autoHeight: false`, or make it narrower than full width.

## Chrome

Reuses the existing variant mechanism rather than inventing a second one — `PortletGroupCard` already draws one frame around frameless `groupChild` children, and a section is the same idea one level up.

- New `sectionChild` card variant: frameless, but keeps standalone semantics. The two transparency flags come apart deliberately — `isTransparent: true` drops the frame while `isTransparentContent: false` keeps the content padding, or a transparent markdown header would sit flush against the section's edge.
- `PortletGroupCard` gains `frameless`, so a grouped KPI strip becomes a band rather than a nested box.
- Inside a section, portlet headers drop their fill, rounding and underline: the section draws one set of rules *between* portlets instead, and a title needs none of its own.
- A header that draws its own bottom line — the `accentBorder: 'bottom'` display option, or markdown ending in `---` — suppresses the section's divider and bleeds to the section edges, so the two never stack as parallel lines a few pixels apart.

## Notes for review

- Section detection lives in a new pure, DOM-free `rowManagedLayout/sections.ts`; the auto-height row predicate moved there too so there is now one definition instead of the copy previously inlined in `RowManagedLayout`.
- The card body's horizontal padding is pinned to one value inside a section. Tailwind's default is responsive (`px-2` → `md:px-4`), which would make the full-bleed offset unknowable.
- Two stable class hooks added for the CSS to reach: `dc-markdown-content` and `dc-portlet-card-body`.
- No new user-facing strings, so no i18n keys.

## Testing

| Suite | Result |
|---|---|
| `test:client` | 6459 passed (183 files) |
| `test:postgres` | 2533 passed |
| `test:sqlite` | 2493 passed, 40 skipped |
| `test:cli` | 7 passed |
| `lint` / `typecheck` | clean |

New coverage: `sections.test.ts` (banding, header detection, bottom-rule detection), plus render-level assertions that a section wraps header + body rows in view mode, emits **no** section in edit mode, passes the `sectionChild` variant, and that mobile bands in rows mode but not grid mode.

Verified visually against a real rows-mode dashboard on desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)